### PR TITLE
fix typo in set_local_id

### DIFF
--- a/csv2dict/Csv2Dict.py
+++ b/csv2dict/Csv2Dict.py
@@ -151,11 +151,11 @@ class Csv2Dict:
 
     def set_local_id(self, local_id, n):
         if self.verify_local_id(local_id):
-            if not 'ucldc_schema:localitendifier' in self.meta_dicts[n]['properties'].keys():
+            if not 'ucldc_schema:localidentifier' in self.meta_dicts[n]['properties'].keys():
                 print "Making localidentifier element, %s" % local_id
                 self.meta_dicts[n]['properties']['ucldc_schema:localidentifier'] = ["%s" % local_id]
             else:
-                print "Adding localidentier item, %s" % local_id
+                print "Adding localidentifier item, %s" % local_id
                 self.meta_dicts[n]['properties']['ucldc_schema:localidentifier'].append("%s" % local_id)
 
     def verify_local_id(self, local_id):


### PR DESCRIPTION
When I tried to ingest metadata with columns "Local Identifier 1" and "Local Identifier 2", 2 was overwriting 1, rather than both being added. Fixing the misspelling in line 154 seems to fix it.