### PR TITLE
fix key for Language Code property so value can be properly retrieved

### DIFF
--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -139,7 +139,7 @@ def get_simple_fields(data2, nxdoc):
         "Copyright Jurisdiction": "ucldc_schema:rightsjurisdiction",
         "Copyright Note": "ucldc_schema:rightsnote",
         "Source": "ucldc_schema:source",
-        "Physical Location": "ucldc_schema:physloc"
+        "Physical Location": "ucldc_schema:physlocation"
     }
 
     for key, value in property_map.items():

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -25,94 +25,133 @@ except:
 
 from pynux import utils
 
-def get_title(data2, x): #gets title
+
+def get_title(data2, x):  #gets title
     data2['Title'] = x['properties']['dc:title']
 
-def get_filepath(data2, x): #gets filepath
+
+def get_filepath(data2, x):  #gets filepath
     data2['File path'] = x['path']
 
-def get_type(data2, x, all_headers): #gets type, inputs are dictionary (data2), nuxeo (x), all_headers input
-    if x['properties']['ucldc_schema:type'] != None and x['properties']['ucldc_schema:type'] != '':
+
+def get_type(
+    data2, x, all_headers
+):  #gets type, inputs are dictionary (data2), nuxeo (x), all_headers input
+    if x['properties']['ucldc_schema:type'] != None and x['properties'][
+            'ucldc_schema:type'] != '':
         data2['Type'] = x['properties']['ucldc_schema:type']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Type'] = ''
 
-def get_alt_title(data2, x, all_headers): 
+
+def get_alt_title(data2, x, all_headers):
     altnumb = 0
-    if type(x['properties']['ucldc_schema:alternativetitle']) == list and len(x['properties']['ucldc_schema:alternativetitle']) > 0:
+    if type(x['properties']['ucldc_schema:alternativetitle']) == list and len(
+            x['properties']['ucldc_schema:alternativetitle']) > 0:
         while altnumb < len(x['properties']['ucldc_schema:alternativetitle']):
             numb = altnumb + 1
             name = 'Alternative Title %d' % numb
-            data2[name]= x['properties']['ucldc_schema:alternativetitle'][altnumb]
+            data2[name] = x['properties']['ucldc_schema:alternativetitle'][
+                altnumb]
             altnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Alternative Title 1'] = ''
+
+
 def get_identifier(data2, x, all_headers):
-    if x['properties']['ucldc_schema:identifier'] != None and x['properties']['ucldc_schema:identifier'] != '':
+    if x['properties']['ucldc_schema:identifier'] != None and x['properties'][
+            'ucldc_schema:identifier'] != '':
         data2['Identifier'] = x['properties']['ucldc_schema:identifier']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Identifier'] = ''
+
+
 def get_local_identifier(data2, x, all_headers):
     locnumb = 0
-    if type(x['properties']['ucldc_schema:localidentifier']) == list and len(x['properties']['ucldc_schema:localidentifier']) > 0:
+    if type(x['properties']['ucldc_schema:localidentifier']) == list and len(
+            x['properties']['ucldc_schema:localidentifier']) > 0:
         while locnumb < len(x['properties']['ucldc_schema:localidentifier']):
             numb = locnumb + 1
             name = 'Local Identifier %d' % numb
-            data2[name]= x['properties']['ucldc_schema:localidentifier'][locnumb]
+            data2[name] = x['properties']['ucldc_schema:localidentifier'][
+                locnumb]
             locnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Local Identifier 1'] = ''
+
+
 def get_campus_unit(data2, x, all_headers):
     campnumb = 0
-    if type(x['properties']['ucldc_schema:campusunit']) == list and len(x['properties']['ucldc_schema:campusunit']) > 0:
+    if type(x['properties']['ucldc_schema:campusunit']) == list and len(
+            x['properties']['ucldc_schema:campusunit']) > 0:
         while campnumb < len(x['properties']['ucldc_schema:campusunit']):
             numb = campnumb + 1
             name = 'Campus/Unit %d' % numb
-            data2[name]= x['properties']['ucldc_schema:campusunit'][campnumb]
+            data2[name] = x['properties']['ucldc_schema:campusunit'][campnumb]
             campnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Campus/Unit 1'] = ''
+
+
 def get_date(data2, x, all_headers):
     datenumb = 0
-    if type(x['properties']['ucldc_schema:date']) == list and len(x['properties']['ucldc_schema:date']) > 0:
+    if type(x['properties']['ucldc_schema:date']) == list and len(
+            x['properties']['ucldc_schema:date']) > 0:
         while datenumb < len(x['properties']['ucldc_schema:date']):
             numb = datenumb + 1
             try:
                 name = 'Date %d' % numb
-                if x['properties']['ucldc_schema:date'][datenumb]['date'] != None and x['properties']['ucldc_schema:date'][datenumb]['date'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][datenumb]['date']
+                if x['properties']['ucldc_schema:date'][datenumb][
+                        'date'] != None and x['properties'][
+                            'ucldc_schema:date'][datenumb]['date'] != '':
+                    data2[name] = x['properties']['ucldc_schema:date'][
+                        datenumb]['date']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Date %d Type' % numb
-                if x['properties']['ucldc_schema:date'][datenumb]['datetype'] != None and x['properties']['ucldc_schema:date'][datenumb]['datetype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][datenumb]['datetype']
+                if x['properties']['ucldc_schema:date'][datenumb][
+                        'datetype'] != None and x['properties'][
+                            'ucldc_schema:date'][datenumb]['datetype'] != '':
+                    data2[name] = x['properties']['ucldc_schema:date'][
+                        datenumb]['datetype']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Date %d Inclusive Start' % numb
-                if x['properties']['ucldc_schema:date'][datenumb]['inclusivestart'] != None and x['properties']['ucldc_schema:date'][datenumb]['inclusivestart'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][datenumb]['inclusivestart']
+                if x['properties']['ucldc_schema:date'][datenumb][
+                        'inclusivestart'] != None and x['properties'][
+                            'ucldc_schema:date'][datenumb][
+                                'inclusivestart'] != '':
+                    data2[name] = x['properties']['ucldc_schema:date'][
+                        datenumb]['inclusivestart']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Date %d Inclusive End' % numb
-                if x['properties']['ucldc_schema:date'][datenumb]['inclusiveend'] != None and x['properties']['ucldc_schema:date'][datenumb]['inclusiveend'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][datenumb]['inclusiveend']
+                if x['properties']['ucldc_schema:date'][datenumb][
+                        'inclusiveend'] != None and x['properties'][
+                            'ucldc_schema:date'][datenumb][
+                                'inclusiveend'] != '':
+                    data2[name] = x['properties']['ucldc_schema:date'][
+                        datenumb]['inclusiveend']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Date %d Single' % numb
-                if x['properties']['ucldc_schema:date'][datenumb]['single'] != None and x['properties']['ucldc_schema:date'][datenumb]['single'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][datenumb]['single']
+                if x['properties']['ucldc_schema:date'][datenumb][
+                        'single'] != None and x['properties'][
+                            'ucldc_schema:date'][datenumb]['single'] != '':
+                    data2[name] = x['properties']['ucldc_schema:date'][
+                        datenumb]['single']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -124,58 +163,80 @@ def get_date(data2, x, all_headers):
         data2['Date 1 Inclusive Start'] = ''
         data2['Date 1 Inclusive End'] = ''
         data2['Date 1 Single'] = ''
+
+
 def get_publication(data2, x, all_headers):
     pubnumb = 0
-    if type(x['properties']['ucldc_schema:publisher']) == list and len(x['properties']['ucldc_schema:publisher']) > 0:
+    if type(x['properties']['ucldc_schema:publisher']) == list and len(
+            x['properties']['ucldc_schema:publisher']) > 0:
         while pubnumb < len(x['properties']['ucldc_schema:publisher']):
             numb = pubnumb + 1
             name = 'Publication/Origination Info %d' % numb
-            data2[name]= x['properties']['ucldc_schema:publisher'][pubnumb]
+            data2[name] = x['properties']['ucldc_schema:publisher'][pubnumb]
             pubnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Publication/Origination Info 1'] = ''
 
+
 def get_creator(data2, x, all_headers):
     creatnumb = 0
-    if type(x['properties']['ucldc_schema:creator']) == list and len(x['properties']['ucldc_schema:creator']) > 0:
+    if type(x['properties']['ucldc_schema:creator']) == list and len(
+            x['properties']['ucldc_schema:creator']) > 0:
         while creatnumb < len(x['properties']['ucldc_schema:creator']):
             numb = creatnumb + 1
             try:
                 name = 'Creator %d Name' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb]['name'] != None and x['properties']['ucldc_schema:creator'][creatnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][creatnumb]['name']
+                if x['properties']['ucldc_schema:creator'][creatnumb][
+                        'name'] != None and x['properties'][
+                            'ucldc_schema:creator'][creatnumb]['name'] != '':
+                    data2[name] = x['properties']['ucldc_schema:creator'][
+                        creatnumb]['name']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Creator %d Name Type' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb]['nametype'] != None and x['properties']['ucldc_schema:creator'][creatnumb]['nametype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][creatnumb]['nametype']
+                if x['properties']['ucldc_schema:creator'][creatnumb][
+                        'nametype'] != None and x['properties'][
+                            'ucldc_schema:creator'][creatnumb][
+                                'nametype'] != '':
+                    data2[name] = x['properties']['ucldc_schema:creator'][
+                        creatnumb]['nametype']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Creator %d Role' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb]['role'] != None and x['properties']['ucldc_schema:creator'][creatnumb]['role'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][creatnumb]['role']
+                if x['properties']['ucldc_schema:creator'][creatnumb][
+                        'role'] != None and x['properties'][
+                            'ucldc_schema:creator'][creatnumb]['role'] != '':
+                    data2[name] = x['properties']['ucldc_schema:creator'][
+                        creatnumb]['role']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Creator %d Source' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb]['source'] != None and x['properties']['ucldc_schema:creator'][creatnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][creatnumb]['source']
+                if x['properties']['ucldc_schema:creator'][creatnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:creator'][creatnumb]['source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:creator'][
+                        creatnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Creator %d Authority ID' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb]['authorityid'] != None and x['properties']['ucldc_schema:creator'][creatnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][creatnumb]['authorityid']
+                if x['properties']['ucldc_schema:creator'][creatnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:creator'][creatnumb][
+                                'authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:creator'][
+                        creatnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -188,47 +249,67 @@ def get_creator(data2, x, all_headers):
         data2['Creator 1 Source'] = ''
         data2['Creator 1 Authority ID'] = ''
 
+
 def get_contributor(data2, x, all_headers):
     contnumb = 0
-    if type(x['properties']['ucldc_schema:contributor']) == list and len(x['properties']['ucldc_schema:contributor']) > 0:
+    if type(x['properties']['ucldc_schema:contributor']) == list and len(
+            x['properties']['ucldc_schema:contributor']) > 0:
         while contnumb < len(x['properties']['ucldc_schema:contributor']):
             numb = contnumb + 1
             try:
                 name = 'Contributor %d Name' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb]['name'] != None and x['properties']['ucldc_schema:contributor'][contnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][contnumb]['name']
+                if x['properties']['ucldc_schema:contributor'][contnumb][
+                        'name'] != None and x['properties'][
+                            'ucldc_schema:contributor'][contnumb]['name'] != '':
+                    data2[name] = x['properties']['ucldc_schema:contributor'][
+                        contnumb]['name']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Contributor %d Name Type' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb]['nametype'] != None and x['properties']['ucldc_schema:contributor'][contnumb]['nametype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][contnumb]['nametype']
+                if x['properties']['ucldc_schema:contributor'][contnumb][
+                        'nametype'] != None and x['properties'][
+                            'ucldc_schema:contributor'][contnumb][
+                                'nametype'] != '':
+                    data2[name] = x['properties']['ucldc_schema:contributor'][
+                        contnumb]['nametype']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Contributor %d Role' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb]['role'] != None and x['properties']['ucldc_schema:contributor'][contnumb]['role'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][contnumb]['role']
+                if x['properties']['ucldc_schema:contributor'][contnumb][
+                        'role'] != None and x['properties'][
+                            'ucldc_schema:contributor'][contnumb]['role'] != '':
+                    data2[name] = x['properties']['ucldc_schema:contributor'][
+                        contnumb]['role']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Contributor %d Source' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb]['source'] != None and x['properties']['ucldc_schema:contributor'][contnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][contnumb]['source']
+                if x['properties']['ucldc_schema:contributor'][contnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:contributor'][contnumb][
+                                'source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:contributor'][
+                        contnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Contributor %d Authority ID' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb]['authorityid'] != None and x['properties']['ucldc_schema:contributor'][contnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][contnumb]['authorityid']
+                if x['properties']['ucldc_schema:contributor'][contnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:contributor'][contnumb][
+                                'authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:contributor'][
+                        contnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -241,28 +322,40 @@ def get_contributor(data2, x, all_headers):
         data2['Contributor 1 Source'] = ''
         data2['Contributor 1 Authority ID'] = ''
 
+
 def get_format(data2, x, all_headers):
-    if x['properties']['ucldc_schema:physdesc'] != None and x['properties']['ucldc_schema:physdesc'] != '':
-        data2['Format/Physical Description'] = x['properties']['ucldc_schema:physdesc']
+    if x['properties']['ucldc_schema:physdesc'] != None and x['properties'][
+            'ucldc_schema:physdesc'] != '':
+        data2['Format/Physical Description'] = x['properties'][
+            'ucldc_schema:physdesc']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Format/Physical Description'] = ''
+
+
 def get_description(data2, x, all_headers):
     descnumb = 0
-    if type(x['properties']['ucldc_schema:description']) == list and len(x['properties']['ucldc_schema:description']) > 0:
+    if type(x['properties']['ucldc_schema:description']) == list and len(
+            x['properties']['ucldc_schema:description']) > 0:
         while descnumb < len(x['properties']['ucldc_schema:description']):
             numb = descnumb + 1
             try:
                 name = "Description %d Note" % numb
-                if x['properties']['ucldc_schema:description'][descnumb]['item'] != None and x['properties']['ucldc_schema:description'][descnumb]['item'] != '':
-                    data2[name] = x['properties']['ucldc_schema:description'][descnumb]['item']
+                if x['properties']['ucldc_schema:description'][descnumb][
+                        'item'] != None and x['properties'][
+                            'ucldc_schema:description'][descnumb]['item'] != '':
+                    data2[name] = x['properties']['ucldc_schema:description'][
+                        descnumb]['item']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = "Description %d Type" % numb
-                if x['properties']['ucldc_schema:description'][descnumb]['type'] != None and x['properties']['ucldc_schema:description'][descnumb]['type'] != '':
-                    data2[name] = x['properties']['ucldc_schema:description'][descnumb]['type']
+                if x['properties']['ucldc_schema:description'][descnumb][
+                        'type'] != None and x['properties'][
+                            'ucldc_schema:description'][descnumb]['type'] != '':
+                    data2[name] = x['properties']['ucldc_schema:description'][
+                        descnumb]['type']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -271,28 +364,42 @@ def get_description(data2, x, all_headers):
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Description 1 Note'] = ''
         data2['Description 1 Type'] = ''
+
+
 def get_extent(data2, x, all_headers):
-    if x['properties']['ucldc_schema:extent'] != None and x['properties']['ucldc_schema:extent'] != '':
+    if x['properties']['ucldc_schema:extent'] != None and x['properties'][
+            'ucldc_schema:extent'] != '':
         data2['Extent'] = x['properties']['ucldc_schema:extent']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Extent'] = ''
+
+
 def get_language(data2, x, all_headers):
     langnumb = 0
-    if type(x['properties']['ucldc_schema:language']) == list and len(x['properties']['ucldc_schema:language']) > 0:
+    if type(x['properties']['ucldc_schema:language']) == list and len(
+            x['properties']['ucldc_schema:language']) > 0:
         while langnumb < len(x['properties']['ucldc_schema:language']):
             numb = langnumb + 1
             try:
                 name = "Language %d" % numb
-                if x['properties']['ucldc_schema:language'][langnumb]['language'] != None and x['properties']['ucldc_schema:language'][langnumb]['language'] != '':
-                    data2[name] = x['properties']['ucldc_schema:language'][langnumb]['language']
+                if x['properties']['ucldc_schema:language'][langnumb][
+                        'language'] != None and x['properties'][
+                            'ucldc_schema:language'][langnumb][
+                                'language'] != '':
+                    data2[name] = x['properties']['ucldc_schema:language'][
+                        langnumb]['language']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = "Language %d Code" % numb
-                if x['properties']['ucldc_schema:language'][langnumb]['languagecode'] != None and x['properties']['ucldc_schema:language'][langnumb]['languagecode'] != '':
-                    data2[name] = x['properties']['ucldc_schema:language'][langnumb]['languagecode']
+                if x['properties']['ucldc_schema:language'][langnumb][
+                        'languagecode'] != None and x['properties'][
+                            'ucldc_schema:language'][langnumb][
+                                'languagecode'] != '':
+                    data2[name] = x['properties']['ucldc_schema:language'][
+                        langnumb]['languagecode']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -302,71 +409,106 @@ def get_language(data2, x, all_headers):
         data2['Language 1'] = ''
         data2['Language 1 Code'] = ''
 
+
 def get_temporal_coverage(data2, x, all_headers):
     tempnumb = 0
-    if type(x['properties']['ucldc_schema:temporalcoverage']) == list and len(x['properties']['ucldc_schema:temporalcoverage']) > 0:
+    if type(x['properties']['ucldc_schema:temporalcoverage']) == list and len(
+            x['properties']['ucldc_schema:temporalcoverage']) > 0:
         while tempnumb < len(x['properties']['ucldc_schema:temporalcoverage']):
             numb = tempnumb + 1
             name = 'Temporal Coverage %d' % numb
-            data2[name]= x['properties']['ucldc_schema:temporalcoverage'][tempnumb]
+            data2[name] = x['properties']['ucldc_schema:temporalcoverage'][
+                tempnumb]
             tempnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Temporal Coverage 1'] = ''
 
+
 def get_transcription(data2, x, all_headers):
-    if x['properties']['ucldc_schema:transcription'] != None and x['properties']['ucldc_schema:transcription'] != '':
+    if x['properties']['ucldc_schema:transcription'] != None and x[
+            'properties']['ucldc_schema:transcription'] != '':
         data2['Transcription'] = x['properties']['ucldc_schema:transcription']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Transcription'] = ''
 
+
 def get_access_restrictions(data2, x, all_headers):
-    if x['properties']['ucldc_schema:accessrestrict'] != None and x['properties']['ucldc_schema:accessrestrict'] != '':
-        data2['Access Restrictions'] = x['properties']['ucldc_schema:accessrestrict']
+    if x['properties']['ucldc_schema:accessrestrict'] != None and x[
+            'properties']['ucldc_schema:accessrestrict'] != '':
+        data2['Access Restrictions'] = x['properties'][
+            'ucldc_schema:accessrestrict']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Access Restrictions'] = ''
+
+
 def get_rights_statement(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightsstatement'] != None and x['properties']['ucldc_schema:rightsstatement'] != '':
-        data2['Copyright Statement'] = x['properties']['ucldc_schema:rightsstatement']
+    if x['properties']['ucldc_schema:rightsstatement'] != None and x[
+            'properties']['ucldc_schema:rightsstatement'] != '':
+        data2['Copyright Statement'] = x['properties'][
+            'ucldc_schema:rightsstatement']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Statement'] = ''
+
+
 def get_rights_status(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightsstatus'] != None and x['properties']['ucldc_schema:rightsstatus'] != '':
-        data2['Copyright Status'] = x['properties']['ucldc_schema:rightsstatus']
+    if x['properties']['ucldc_schema:rightsstatus'] != None and x[
+            'properties']['ucldc_schema:rightsstatus'] != '':
+        data2['Copyright Status'] = x['properties'][
+            'ucldc_schema:rightsstatus']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Status'] = ''
+
+
 def get_copyright_holder(data2, x, all_headers):
     rightsnumb = 0
-    if type(x['properties']['ucldc_schema:rightsholder']) == list and len(x['properties']['ucldc_schema:rightsholder']) > 0:
+    if type(x['properties']['ucldc_schema:rightsholder']) == list and len(
+            x['properties']['ucldc_schema:rightsholder']) > 0:
         while rightsnumb < len(x['properties']['ucldc_schema:rightsholder']):
             numb = rightsnumb + 1
             try:
                 name = 'Copyright Holder %d Name' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb]['name'] != None and x['properties']['ucldc_schema:rightsholder'][rightsnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][rightsnumb]['name']
+                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
+                        'name'] != None and x['properties'][
+                            'ucldc_schema:rightsholder'][rightsnumb][
+                                'name'] != '':
+                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
+                        rightsnumb]['name']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Copyright Holder %d Name Type' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb]['nametype'] != None and x['properties']['ucldc_schema:rightsholder'][rightsnumb]['nametype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][rightsnumb]['nametype']
+                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
+                        'nametype'] != None and x['properties'][
+                            'ucldc_schema:rightsholder'][rightsnumb][
+                                'nametype'] != '':
+                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
+                        rightsnumb]['nametype']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Copyright Holder %d Source' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb]['source'] != None and x['properties']['ucldc_schema:rightsholder'][rightsnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][rightsnumb]['source']
+                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:rightsholder'][rightsnumb][
+                                'source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
+                        rightsnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Copyright Holder %d Authority ID' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb]['authorityid'] != None and x['properties']['ucldc_schema:rightsholder'][rightsnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][rightsnumb]['authorityid']
+                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:rightsholder'][rightsnumb][
+                                'authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
+                        rightsnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -378,111 +520,152 @@ def get_copyright_holder(data2, x, all_headers):
         data2['Copyright Holder 1 Source'] = ''
         data2['Copyright Holder 1 Authority ID'] = ''
 
+
 def get_copyright_info(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightscontact'] != None and x['properties']['ucldc_schema:rightscontact'] != '':
-        data2['Copyright Contact'] = x['properties']['ucldc_schema:rightscontact']
+    if x['properties']['ucldc_schema:rightscontact'] != None and x[
+            'properties']['ucldc_schema:rightscontact'] != '':
+        data2['Copyright Contact'] = x['properties'][
+            'ucldc_schema:rightscontact']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Contact'] = ''
 
-    if x['properties']['ucldc_schema:rightsnotice'] != None and x['properties']['ucldc_schema:rightsnotice'] != '':
-        data2['Copyright Notice'] = x['properties']['ucldc_schema:rightsnotice']
+    if x['properties']['ucldc_schema:rightsnotice'] != None and x[
+            'properties']['ucldc_schema:rightsnotice'] != '':
+        data2['Copyright Notice'] = x['properties'][
+            'ucldc_schema:rightsnotice']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Notice'] = ''
 
-    if x['properties']['ucldc_schema:rightsdeterminationdate'] != None and x['properties']['ucldc_schema:rightsdeterminationdate'] != '':
-        data2['Copyright Determination Date'] = x['properties']['ucldc_schema:rightsdeterminationdate']
+    if x['properties']['ucldc_schema:rightsdeterminationdate'] != None and x[
+            'properties']['ucldc_schema:rightsdeterminationdate'] != '':
+        data2['Copyright Determination Date'] = x['properties'][
+            'ucldc_schema:rightsdeterminationdate']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Determination Date'] = ''
 
-    if x['properties']['ucldc_schema:rightsstartdate'] != None and x['properties']['ucldc_schema:rightsstartdate'] != '':
-        data2['Copyright Start Date'] = x['properties']['ucldc_schema:rightsstartdate']
+    if x['properties']['ucldc_schema:rightsstartdate'] != None and x[
+            'properties']['ucldc_schema:rightsstartdate'] != '':
+        data2['Copyright Start Date'] = x['properties'][
+            'ucldc_schema:rightsstartdate']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Start Date'] = ''
 
-    if x['properties']['ucldc_schema:rightsenddate'] != None and x['properties']['ucldc_schema:rightsenddate'] != '':
-        data2['Copyright End Date'] = x['properties']['ucldc_schema:rightsenddate']
+    if x['properties']['ucldc_schema:rightsenddate'] != None and x[
+            'properties']['ucldc_schema:rightsenddate'] != '':
+        data2['Copyright End Date'] = x['properties'][
+            'ucldc_schema:rightsenddate']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright End Date'] = ''
 
-    if x['properties']['ucldc_schema:rightsjurisdiction'] != None and x['properties']['ucldc_schema:rightsjurisdiction'] != '':
-        data2['Copyright Jurisdiction'] = x['properties']['ucldc_schema:rightsjurisdiction']
+    if x['properties']['ucldc_schema:rightsjurisdiction'] != None and x[
+            'properties']['ucldc_schema:rightsjurisdiction'] != '':
+        data2['Copyright Jurisdiction'] = x['properties'][
+            'ucldc_schema:rightsjurisdiction']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Jurisdiction'] = ''
 
-    if x['properties']['ucldc_schema:rightsnote'] != None and x['properties']['ucldc_schema:rightsnote'] != '':
+    if x['properties']['ucldc_schema:rightsnote'] != None and x['properties'][
+            'ucldc_schema:rightsnote'] != '':
         data2['Copyright Note'] = x['properties']['ucldc_schema:rightsnote']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Copyright Note'] = ''
 
+
 def get_collection(data2, x, all_headers):
     collnumb = 0
-    if type(x['properties']['ucldc_schema:collection']) == list and len(x['properties']['ucldc_schema:collection']) > 0:
+    if type(x['properties']['ucldc_schema:collection']) == list and len(
+            x['properties']['ucldc_schema:collection']) > 0:
         while collnumb < len(x['properties']['ucldc_schema:collection']):
             numb = collnumb + 1
             name = 'Collection %d' % numb
-            data2[name]= x['properties']['ucldc_schema:collection'][collnumb]
+            data2[name] = x['properties']['ucldc_schema:collection'][collnumb]
             collnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Collection 1'] = ''
 
+
 def get_related_resource(data2, x, all_headers):
     relnumb = 0
-    if type(x['properties']['ucldc_schema:relatedresource']) == list and len(x['properties']['ucldc_schema:relatedresource']) > 0:
+    if type(x['properties']['ucldc_schema:relatedresource']) == list and len(
+            x['properties']['ucldc_schema:relatedresource']) > 0:
         while relnumb < len(x['properties']['ucldc_schema:relatedresource']):
             numb = relnumb + 1
             name = 'Related Resource %d' % numb
-            data2[name]= x['properties']['ucldc_schema:relatedresource'][relnumb]
+            data2[name] = x['properties']['ucldc_schema:relatedresource'][
+                relnumb]
             relnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Related Resource 1'] = ''
 
+
 def get_source(data2, x, all_headers):
-    if x['properties']['ucldc_schema:source'] != None and x['properties']['ucldc_schema:source'] != '':
+    if x['properties']['ucldc_schema:source'] != None and x['properties'][
+            'ucldc_schema:source'] != '':
         data2['Source'] = x['properties']['ucldc_schema:source']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Source'] = ''
 
+
 def get_subject_name(data2, x, all_headers):
     subnumb = 0
-    if type(x['properties']['ucldc_schema:subjectname']) == list and len(x['properties']['ucldc_schema:subjectname']) > 0:
+    if type(x['properties']['ucldc_schema:subjectname']) == list and len(
+            x['properties']['ucldc_schema:subjectname']) > 0:
         while subnumb < len(x['properties']['ucldc_schema:subjectname']):
             numb = subnumb + 1
             try:
                 name = 'Subject (Name) %d Name' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb]['name'] != None and x['properties']['ucldc_schema:subjectname'][subnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][subnumb]['name']
+                if x['properties']['ucldc_schema:subjectname'][subnumb][
+                        'name'] != None and x['properties'][
+                            'ucldc_schema:subjectname'][subnumb]['name'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjectname'][
+                        subnumb]['name']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Name) %d Name Type' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb]['name_type'] != None and x['properties']['ucldc_schema:subjectname'][subnumb]['name_type'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][subnumb]['name_type']
+                if x['properties']['ucldc_schema:subjectname'][subnumb][
+                        'name_type'] != None and x['properties'][
+                            'ucldc_schema:subjectname'][subnumb][
+                                'name_type'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjectname'][
+                        subnumb]['name_type']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Name) %d Role' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb]['role'] != None and x['properties']['ucldc_schema:subjectname'][subnumb]['role'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][subnumb]['role']
+                if x['properties']['ucldc_schema:subjectname'][subnumb][
+                        'role'] != None and x['properties'][
+                            'ucldc_schema:subjectname'][subnumb]['role'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjectname'][
+                        subnumb]['role']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Name) %d Source' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb]['source'] != None and x['properties']['ucldc_schema:subjectname'][subnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][subnumb]['source']
+                if x['properties']['ucldc_schema:subjectname'][subnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:subjectname'][subnumb][
+                                'source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjectname'][
+                        subnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Name) %d Authority ID' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb]['authorityid'] != None and x['properties']['ucldc_schema:subjectname'][subnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][subnumb]['authorityid']
+                if x['properties']['ucldc_schema:subjectname'][subnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:subjectname'][subnumb][
+                                'authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjectname'][
+                        subnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -495,39 +678,53 @@ def get_subject_name(data2, x, all_headers):
         data2['Subject (Name) 1 Source'] = ''
         data2['Subject (Name) 1 Authority ID'] = ''
 
+
 def get_place(data2, x, all_headers):
     plcnumb = 0
-    if type(x['properties']['ucldc_schema:place']) == list and len(x['properties']['ucldc_schema:place']) > 0:
+    if type(x['properties']['ucldc_schema:place']) == list and len(
+            x['properties']['ucldc_schema:place']) > 0:
         while plcnumb < len(x['properties']['ucldc_schema:place']):
             numb = plcnumb + 1
             try:
                 name = 'Place %d Name' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb]['name'] != None and x['properties']['ucldc_schema:place'][plcnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][plcnumb]['name']
+                if x['properties']['ucldc_schema:place'][plcnumb][
+                        'name'] != None and x['properties'][
+                            'ucldc_schema:place'][plcnumb]['name'] != '':
+                    data2[name] = x['properties']['ucldc_schema:place'][
+                        plcnumb]['name']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Place %d Coordinates' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb]['coordinates'] != None and x['properties']['ucldc_schema:place'][plcnumb]['coordinates'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][plcnumb]['coordinates']
+                if x['properties']['ucldc_schema:place'][plcnumb][
+                        'coordinates'] != None and x['properties'][
+                            'ucldc_schema:place'][plcnumb]['coordinates'] != '':
+                    data2[name] = x['properties']['ucldc_schema:place'][
+                        plcnumb]['coordinates']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Place %d Source' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb]['source'] != None and x['properties']['ucldc_schema:place'][plcnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][plcnumb]['source']
+                if x['properties']['ucldc_schema:place'][plcnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:place'][plcnumb]['source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:place'][
+                        plcnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Place %d Authority ID' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb]['authorityid'] != None and x['properties']['ucldc_schema:place'][plcnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][plcnumb]['authorityid']
+                if x['properties']['ucldc_schema:place'][plcnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:place'][plcnumb]['authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:place'][
+                        plcnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -539,39 +736,57 @@ def get_place(data2, x, all_headers):
         data2['Place 1 Source'] = ''
         data2['Place 1 Authority ID'] = ''
 
+
 def get_subject_topic(data2, x, all_headers):
     topnumb = 0
-    if type(x['properties']['ucldc_schema:subjecttopic']) == list and len(x['properties']['ucldc_schema:subjecttopic']) > 0:
+    if type(x['properties']['ucldc_schema:subjecttopic']) == list and len(
+            x['properties']['ucldc_schema:subjecttopic']) > 0:
         while topnumb < len(x['properties']['ucldc_schema:subjecttopic']):
             numb = topnumb + 1
             try:
                 name = 'Subject (Topic) %d Heading' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb]['heading'] != None and x['properties']['ucldc_schema:subjecttopic'][topnumb]['heading'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][topnumb]['heading']
+                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
+                        'heading'] != None and x['properties'][
+                            'ucldc_schema:subjecttopic'][topnumb][
+                                'heading'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
+                        topnumb]['heading']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Topic) %d Heading Type' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb]['headingtype'] != None and x['properties']['ucldc_schema:subjecttopic'][topnumb]['headingtype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][topnumb]['headingtype']
+                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
+                        'headingtype'] != None and x['properties'][
+                            'ucldc_schema:subjecttopic'][topnumb][
+                                'headingtype'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
+                        topnumb]['headingtype']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Topic) %d Source' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb]['source'] != None and x['properties']['ucldc_schema:subjecttopic'][topnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][topnumb]['source']
+                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:subjecttopic'][topnumb][
+                                'source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
+                        topnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Subject (Topic) %d Authority ID' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb]['authorityid'] != None and x['properties']['ucldc_schema:subjecttopic'][topnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][topnumb]['authorityid']
+                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:subjecttopic'][topnumb][
+                                'authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
+                        topnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -583,31 +798,44 @@ def get_subject_topic(data2, x, all_headers):
         data2['Subject (Topic) 1 Source'] = ''
         data2['Subject (Topic) 1 Authority ID'] = ''
 
+
 def get_form_genre(data2, x, all_headers):
     formnumb = 0
-    if type(x['properties']['ucldc_schema:formgenre']) == list and len(x['properties']['ucldc_schema:formgenre']) > 0:
+    if type(x['properties']['ucldc_schema:formgenre']) == list and len(
+            x['properties']['ucldc_schema:formgenre']) > 0:
         while formnumb < len(x['properties']['ucldc_schema:formgenre']):
             numb = formnumb + 1
             try:
                 name = 'Form/Genre %d Heading' % numb
-                if x['properties']['ucldc_schema:formgenre'][formnumb]['heading'] != None and x['properties']['ucldc_schema:formgenre'][formnumb]['heading'] != '':
-                    data2[name] = x['properties']['ucldc_schema:formgenre'][formnumb]['heading']
+                if x['properties']['ucldc_schema:formgenre'][formnumb][
+                        'heading'] != None and x['properties'][
+                            'ucldc_schema:formgenre'][formnumb][
+                                'heading'] != '':
+                    data2[name] = x['properties']['ucldc_schema:formgenre'][
+                        formnumb]['heading']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Form/Genre %d Source' % numb
-                if x['properties']['ucldc_schema:formgenre'][formnumb]['source'] != None and x['properties']['ucldc_schema:formgenre'][formnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:formgenre'][formnumb]['source']
+                if x['properties']['ucldc_schema:formgenre'][formnumb][
+                        'source'] != None and x['properties'][
+                            'ucldc_schema:formgenre'][formnumb]['source'] != '':
+                    data2[name] = x['properties']['ucldc_schema:formgenre'][
+                        formnumb]['source']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
                 pass
             try:
                 name = 'Form/Genre %d Authority ID' % numb
-                if x['properties']['ucldc_schema:formgenre'][formnumb]['authorityid'] != None and x['properties']['ucldc_schema:formgenre'][formnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:formgenre'][formnumb]['authorityid']
+                if x['properties']['ucldc_schema:formgenre'][formnumb][
+                        'authorityid'] != None and x['properties'][
+                            'ucldc_schema:formgenre'][formnumb][
+                                'authorityid'] != '':
+                    data2[name] = x['properties']['ucldc_schema:formgenre'][
+                        formnumb]['authorityid']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:
@@ -618,29 +846,35 @@ def get_form_genre(data2, x, all_headers):
         data2['Form/Genre 1 Source'] = ''
         data2['Form/Genre 1 Authority ID'] = ''
 
+
 def get_provenance(data2, x, all_headers):
     provnumb = 0
-    if type(x['properties']['ucldc_schema:provenance']) == list and len(x['properties']['ucldc_schema:provenance']) > 0:
+    if type(x['properties']['ucldc_schema:provenance']) == list and len(
+            x['properties']['ucldc_schema:provenance']) > 0:
         while provnumb < len(x['properties']['ucldc_schema:provenance']):
             numb = provnumb + 1
             name = 'Provenance %d' % numb
-            data2[name]= x['properties']['ucldc_schema:provenance'][provnumb]
+            data2[name] = x['properties']['ucldc_schema:provenance'][provnumb]
             provnumb += 1
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Provenance 1'] = ''
 
+
 def get_physical_location(data2, x, all_headers):
-    if x['properties']['ucldc_schema:physlocation'] != None and x['properties']['ucldc_schema:physlocation'] != '':
-        data2['Physical Location'] = x['properties']['ucldc_schema:physlocation']
+    if x['properties']['ucldc_schema:physlocation'] != None and x[
+            'properties']['ucldc_schema:physlocation'] != '':
+        data2['Physical Location'] = x['properties'][
+            'ucldc_schema:physlocation']
     elif all_headers == 'y' or all_headers == 'Y':
         data2['Physical Location'] = ''
+
 
 def object_level(filepath):
     nx = utils.Nuxeo()
     data = []
     for n in nx.children(filepath):
         data2 = {}
-        
+
         get_title(data2, n)
         get_filepath(data2, n)
         get_type(data2, n, all_headers)
@@ -675,13 +909,24 @@ def object_level(filepath):
 
         data.append(data2)
 
-    fieldnames = ['File path', 'Title', 'Type'] #ensures that File path, Title and Type are the first three rows
+    fieldnames = [
+        'File path', 'Title', 'Type'
+    ]  #ensures that File path, Title and Type are the first three rows
     for data2 in data:
         for key, value in data2.items():
             if key not in fieldnames:
                 fieldnames.append(key)
 
-    return {'fieldnames':fieldnames, 'data':data, 'filename':"nuxeo_object_%s.tsv"%nx.get_metadata(path=filepath)['properties']['dc:title']}
+    return {
+        'fieldnames':
+        fieldnames,
+        'data':
+        data,
+        'filename':
+        "nuxeo_object_%s.tsv" %
+        nx.get_metadata(path=filepath)['properties']['dc:title']
+    }
+
 
 def item_level(filepath):
     nx = utils.Nuxeo()
@@ -722,23 +967,39 @@ def item_level(filepath):
             get_physical_location(data2, x, all_headers)
             data.append(data2)
 
-    fieldnames = ['File path', 'Title', 'Type'] #ensures that File path, Title and Type are the first three rows
+    fieldnames = [
+        'File path', 'Title', 'Type'
+    ]  #ensures that File path, Title and Type are the first three rows
     for data2 in data:
         for key, value in data2.items():
             if key not in fieldnames:
                 fieldnames.append(key)
 
-    return {'fieldnames':fieldnames, 'data':data, 'filename':"nuxeo_item_%s.tsv"%nx.get_metadata(path=filepath)['properties']['dc:title']}
-	#returns dictionary with fieldnames, data and filename; This is used for google functions and writing to tsv if google function not choosed
+    return {
+        'fieldnames':
+        fieldnames,
+        'data':
+        data,
+        'filename':
+        "nuxeo_item_%s.tsv" %
+        nx.get_metadata(path=filepath)['properties']['dc:title']
+    }
+
+
+#returns dictionary with fieldnames, data and filename; This is used for google functions and writing to tsv if google function not choosed
+
 
 def google_object(filepath, url):
     import gspread
     from oauth2client.service_account import ServiceAccountCredentials
     obj = object_level(filepath)
     nx = utils.Nuxeo()
-    scope = ['https://spreadsheets.google.com/feeds',
-    'https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name('client_secret.json', scope)
+    scope = [
+        'https://spreadsheets.google.com/feeds',
+        'https://www.googleapis.com/auth/drive'
+    ]
+    creds = ServiceAccountCredentials.from_json_keyfile_name(
+        'client_secret.json', scope)
     client = gspread.authorize(creds)
     with open("temp.csv", "wb") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=obj['fieldnames'])
@@ -749,40 +1010,54 @@ def google_object(filepath, url):
         s = f.read() + '\n'
     sheet_id = client.open_by_url(url).id
     client.import_csv(sheet_id, s)
-    client.open_by_key(sheet_id).sheet1.update_title("nuxeo_object_%s"%nx.get_metadata(path=filepath)['properties']['dc:title'])
+    client.open_by_key(sheet_id).sheet1.update_title(
+        "nuxeo_object_%s" %
+        nx.get_metadata(path=filepath)['properties']['dc:title'])
     os.remove("temp.csv")
+
 
 def google_item(filepath, url):
     import gspread
     from oauth2client.service_account import ServiceAccountCredentials
     item = item_level(filepath)
     nx = utils.Nuxeo()
-    scope = ['https://spreadsheets.google.com/feeds',
-    'https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name('client_secret.json', scope)
+    scope = [
+        'https://spreadsheets.google.com/feeds',
+        'https://www.googleapis.com/auth/drive'
+    ]
+    creds = ServiceAccountCredentials.from_json_keyfile_name(
+        'client_secret.json', scope)
     client = gspread.authorize(creds)
-    with open("temp.csv", "wb") as csvfile: #creates temporary csv file
+    with open("temp.csv", "wb") as csvfile:  #creates temporary csv file
         writer = csv.DictWriter(csvfile, fieldnames=item['fieldnames'])
         writer.writeheader()
         for row in item['data']:
             writer.writerow(row)
-    with open("temp.csv", encoding="utf8") as f: #opens and reads temporary csv file
+    with open("temp.csv",
+              encoding="utf8") as f:  #opens and reads temporary csv file
         s = f.read() + '\n'
-    sheet_id = client.open_by_url(url).id 
-    client.import_csv(sheet_id, s)#writes csv file to google sheet
-    client.open_by_key(sheet_id).sheet1.update_title("nuxeo_item_%s"%nx.get_metadata(path=filepath)['properties']['dc:title'])
-    os.remove("temp.csv") #removes temporary csv
+    sheet_id = client.open_by_url(url).id
+    client.import_csv(sheet_id, s)  #writes csv file to google sheet
+    client.open_by_key(sheet_id).sheet1.update_title(
+        "nuxeo_item_%s" %
+        nx.get_metadata(path=filepath)['properties']['dc:title'])
+    os.remove("temp.csv")  #removes temporary csv
+
 
 if 'O' in choice or 'o' in choice:
     if 'http' in url:
         try:
             google_object(filepath, url)
         except:
-            print("\n*********\nWriting to Google document did not work. Make sure that Google document has been shared with API key email address")
+            print(
+                "\n*********\nWriting to Google document did not work. Make sure that Google document has been shared with API key email address"
+            )
     else:
         obj = object_level(filepath)
         with open(obj['filename'], "wb") as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=obj['fieldnames'], delimiter="\t")
+            writer = csv.DictWriter(csvfile,
+                                    fieldnames=obj['fieldnames'],
+                                    delimiter="\t")
             writer.writeheader()
             for row in obj['data']:
                 writer.writerow(row)
@@ -791,11 +1066,15 @@ if 'I' in choice or 'i' in choice:
         try:
             google_item(filepath, url)
         except:
-            print("\n*********\nWriting to Google document did not work. Make sure that Google document has been shared with API key email address")
+            print(
+                "\n*********\nWriting to Google document did not work. Make sure that Google document has been shared with API key email address"
+            )
     else:
         item = item_level(filepath)
         with open(item['filename'], "wb") as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=item['fieldnames'], delimiter="\t")
+            writer = csv.DictWriter(csvfile,
+                                    fieldnames=item['fieldnames'],
+                                    delimiter="\t")
             writer.writeheader()
             for row in item['data']:
                 writer.writerow(row)

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -92,62 +92,58 @@ def process_metadata(nxdoc, all_headers):
 
     data2 = {}
 
-    get_title(data2, nxdoc)
-    get_filepath(data2, nxdoc)
-    get_type(data2, nxdoc, all_headers)
+    get_simple_fields(data2, nxdoc)
+
     get_alt_title(data2, nxdoc, all_headers)
-    get_identifier(data2, nxdoc, all_headers)
     get_local_identifier(data2, nxdoc, all_headers)
     get_campus_unit(data2, nxdoc, all_headers)
     get_date(data2, nxdoc, all_headers)
     get_publication(data2, nxdoc, all_headers)
     get_creator(data2, nxdoc, all_headers)
     get_contributor(data2, nxdoc, all_headers)
-    get_format(data2, nxdoc, all_headers)
     get_description(data2, nxdoc, all_headers)
-    get_extent(data2, nxdoc, all_headers)
     get_language(data2, nxdoc, all_headers)
     get_temporal_coverage(data2, nxdoc, all_headers)
-    get_transcription(data2, nxdoc, all_headers)
-    get_access_restrictions(data2, nxdoc, all_headers)
-    get_rights_statement(data2, nxdoc, all_headers)
-    get_rights_status(data2, nxdoc, all_headers)
     get_copyright_holder(data2, nxdoc, all_headers)
-    get_copyright_info(data2, nxdoc, all_headers)
     get_collection(data2, nxdoc, all_headers)
     get_related_resource(data2, nxdoc, all_headers)
-    get_source(data2, nxdoc, all_headers)
     get_subject_name(data2, nxdoc, all_headers)
     get_place(data2, nxdoc, all_headers)
     get_subject_topic(data2, nxdoc, all_headers)
     get_form_genre(data2, nxdoc, all_headers)
     get_provenance(data2, nxdoc, all_headers)
-    get_physical_location(data2, nxdoc, all_headers)
 
     return data2
 
 
-def get_title(data2, nxdoc):
-    """gets title
+def get_simple_fields(data2, nxdoc):
+    """ map fields that are non-repeating string values
     """
-    data2["Title"] = nxdoc["properties"]["dc:title"]
 
+    data2["File path"] = nxdoc.get("path")
 
-def get_filepath(data2, nxdoc):
-    """gets filepath
-    """
-    data2["File path"] = nxdoc["path"]
+    property_map = {
+        "Title": "dc:title",
+        "Identifier": "ucldc_schema:identifier",
+        "Type": "ucldc_schema:type",
+        "Format/Physical Description": "ucldc_schema:physdesc",
+        "Extent": "ucldc_schema:extent",
+        "Transcription": "ucldc_schema:transcription",
+        "Access Restrictions": "ucldc_schema:accessrestrict",
+        "Copyright Statement": "ucldc_schema:rightsstatement",
+        "Copyright Status": "ucldc_schema:rightsstatus",
+        "Copyright Contact": "ucldc_schema:rightscontact",
+        "Copyright Notice": "ucldc_schema:rightsnotice",
+        "Copyright Determination Date": "ucldc_schema:rightsdeterminationdate",
+        "Copyright End Date": "ucldc_schema:rightsstartdate",
+        "Copyright Jurisdiction": "ucldc_schema:rightsjurisdiction",
+        "Copyright Note": "ucldc_schema:rightsnote",
+        "Source": "ucldc_schema:source",
+        "Physical Location": "ucldc_schema:physloc"
+    }
 
-
-def get_type(data2, nxdoc, all_headers):
-    """gets type,
-    inputs are dictionary (data2), nuxeo (nxdoc), all_headers input
-    """
-    if nxdoc["properties"]["ucldc_schema:type"] is not None and nxdoc[
-            "properties"]["ucldc_schema:type"] != "":
-        data2["Type"] = nxdoc["properties"]["ucldc_schema:type"]
-    elif all_headers:
-        data2["Type"] = ""
+    for key, value in property_map.items():
+        data2[key] = nxdoc["properties"][value]
 
 
 def get_alt_title(data2, nxdoc, all_headers):
@@ -165,14 +161,6 @@ def get_alt_title(data2, nxdoc, all_headers):
             altnumb += 1
     elif all_headers:
         data2["Alternative Title 1"] = ""
-
-
-def get_identifier(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:identifier"] is not None and nxdoc[
-            "properties"]["ucldc_schema:identifier"] != "":
-        data2["Identifier"] = nxdoc["properties"]["ucldc_schema:identifier"]
-    elif all_headers:
-        data2["Identifier"] = ""
 
 
 def get_local_identifier(data2, nxdoc, all_headers):
@@ -440,15 +428,6 @@ def get_contributor(data2, nxdoc, all_headers):
         data2["Contributor 1 Authority ID"] = ""
 
 
-def get_format(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:physdesc"] is not None and nxdoc[
-            "properties"]["ucldc_schema:physdesc"] != "":
-        data2["Format/Physical Description"] = nxdoc["properties"][
-            "ucldc_schema:physdesc"]
-    elif all_headers:
-        data2["Format/Physical Description"] = ""
-
-
 def get_description(data2, nxdoc, all_headers):
     descnumb = 0
     if isinstance(
@@ -482,14 +461,6 @@ def get_description(data2, nxdoc, all_headers):
     elif all_headers:
         data2["Description 1 Note"] = ""
         data2["Description 1 Type"] = ""
-
-
-def get_extent(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:extent"] is not None and nxdoc[
-            "properties"]["ucldc_schema:extent"] != "":
-        data2["Extent"] = nxdoc["properties"]["ucldc_schema:extent"]
-    elif all_headers:
-        data2["Extent"] = ""
 
 
 def get_language(data2, nxdoc, all_headers):
@@ -544,43 +515,6 @@ def get_temporal_coverage(data2, nxdoc, all_headers):
             tempnumb += 1
     elif all_headers:
         data2["Temporal Coverage 1"] = ""
-
-
-def get_transcription(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:transcription"] is not None and nxdoc[
-            "properties"]["ucldc_schema:transcription"] != "":
-        data2["Transcription"] = nxdoc["properties"][
-            "ucldc_schema:transcription"]
-    elif all_headers:
-        data2["Transcription"] = ""
-
-
-def get_access_restrictions(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:accessrestrict"] is not None and nxdoc[
-            "properties"]["ucldc_schema:accessrestrict"] != "":
-        data2["Access Restrictions"] = nxdoc["properties"][
-            "ucldc_schema:accessrestrict"]
-    elif all_headers:
-        data2["Access Restrictions"] = ""
-
-
-def get_rights_statement(data2, nxdoc, all_headers):
-    if nxdoc["properties"][
-            "ucldc_schema:rightsstatement"] is not None and nxdoc[
-                "properties"]["ucldc_schema:rightsstatement"] != "":
-        data2["Copyright Statement"] = nxdoc["properties"][
-            "ucldc_schema:rightsstatement"]
-    elif all_headers:
-        data2["Copyright Statement"] = ""
-
-
-def get_rights_status(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:rightsstatus"] is not None and nxdoc[
-            "properties"]["ucldc_schema:rightsstatus"] != "":
-        data2["Copyright Status"] = nxdoc["properties"][
-            "ucldc_schema:rightsstatus"]
-    elif all_headers:
-        data2["Copyright Status"] = ""
 
 
 def get_copyright_holder(data2, nxdoc, all_headers):
@@ -647,60 +581,6 @@ def get_copyright_holder(data2, nxdoc, all_headers):
         data2["Copyright Holder 1 Authority ID"] = ""
 
 
-def get_copyright_info(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:rightscontact"] is not None and nxdoc[
-            "properties"]["ucldc_schema:rightscontact"] != "":
-        data2["Copyright Contact"] = nxdoc["properties"][
-            "ucldc_schema:rightscontact"]
-    elif all_headers:
-        data2["Copyright Contact"] = ""
-
-    if nxdoc["properties"]["ucldc_schema:rightsnotice"] is not None and nxdoc[
-            "properties"]["ucldc_schema:rightsnotice"] != "":
-        data2["Copyright Notice"] = nxdoc["properties"][
-            "ucldc_schema:rightsnotice"]
-    elif all_headers:
-        data2["Copyright Notice"] = ""
-
-    if nxdoc["properties"][
-            "ucldc_schema:rightsdeterminationdate"] is not None and nxdoc[
-                "properties"]["ucldc_schema:rightsdeterminationdate"] != "":
-        data2["Copyright Determination Date"] = nxdoc["properties"][
-            "ucldc_schema:rightsdeterminationdate"]
-    elif all_headers:
-        data2["Copyright Determination Date"] = ""
-
-    if nxdoc["properties"][
-            "ucldc_schema:rightsstartdate"] is not None and nxdoc[
-                "properties"]["ucldc_schema:rightsstartdate"] != "":
-        data2["Copyright Start Date"] = nxdoc["properties"][
-            "ucldc_schema:rightsstartdate"]
-    elif all_headers:
-        data2["Copyright Start Date"] = ""
-
-    if nxdoc["properties"]["ucldc_schema:rightsenddate"] is not None and nxdoc[
-            "properties"]["ucldc_schema:rightsenddate"] != "":
-        data2["Copyright End Date"] = nxdoc["properties"][
-            "ucldc_schema:rightsenddate"]
-    elif all_headers:
-        data2["Copyright End Date"] = ""
-
-    if nxdoc["properties"][
-            "ucldc_schema:rightsjurisdiction"] is not None and nxdoc[
-                "properties"]["ucldc_schema:rightsjurisdiction"] != "":
-        data2["Copyright Jurisdiction"] = nxdoc["properties"][
-            "ucldc_schema:rightsjurisdiction"]
-    elif all_headers:
-        data2["Copyright Jurisdiction"] = ""
-
-    if nxdoc["properties"]["ucldc_schema:rightsnote"] is not None and nxdoc[
-            "properties"]["ucldc_schema:rightsnote"] != "":
-        data2["Copyright Note"] = nxdoc["properties"][
-            "ucldc_schema:rightsnote"]
-    elif all_headers:
-        data2["Copyright Note"] = ""
-
-
 def get_collection(data2, nxdoc, all_headers):
     collnumb = 0
     if isinstance(
@@ -730,14 +610,6 @@ def get_related_resource(data2, nxdoc, all_headers):
             relnumb += 1
     elif all_headers:
         data2["Related Resource 1"] = ""
-
-
-def get_source(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:source"] is not None and nxdoc[
-            "properties"]["ucldc_schema:source"] != "":
-        data2["Source"] = nxdoc["properties"]["ucldc_schema:source"]
-    elif all_headers:
-        data2["Source"] = ""
 
 
 def get_subject_name(data2, nxdoc, all_headers):
@@ -997,15 +869,6 @@ def get_provenance(data2, nxdoc, all_headers):
             provnumb += 1
     elif all_headers:
         data2["Provenance 1"] = ""
-
-
-def get_physical_location(data2, nxdoc, all_headers):
-    if nxdoc["properties"]["ucldc_schema:physlocation"] is not None and nxdoc[
-            "properties"]["ucldc_schema:physlocation"] != "":
-        data2["Physical Location"] = nxdoc["properties"][
-            "ucldc_schema:physlocation"]
-    elif all_headers:
-        data2["Physical Location"] = ""
 
 
 def make_fieldnames(data, all_headers):

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -291,8 +291,8 @@ def get_language(data2, x, all_headers):
                 pass
             try:
                 name = "Language %d Code" % numb
-                if x['properties']['ucldc_schema:language'][langnumb]['code'] != None and x['properties']['ucldc_schema:language'][langnumb]['code'] != '':
-                    data2[name] = x['properties']['ucldc_schema:language'][langnumb]['code']
+                if x['properties']['ucldc_schema:language'][langnumb]['languagecode'] != None and x['properties']['ucldc_schema:language'][langnumb]['languagecode'] != '':
+                    data2[name] = x['properties']['ucldc_schema:language'][langnumb]['languagecode']
                 elif all_headers == 'y' or all_headers == 'Y':
                     data2[name] = ''
             except:

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -1,9 +1,16 @@
-#Written by Niqui O'Neill
-#This script requires unicodecsv to be installed
-#This script allows the users to download metadata from nuxeo and place it either in a google spreadsheet or tsv file
-#it also allows for metadata to be downloaded from the collection or item level
-#it also asks if all headers should be downloaded or if the empty items should not be downloaded
-#Nuxeo has to be installed for this script to work
+"""
+This script allows the users to download metadata from Nuxeo
+and save to either a Google Sheets spreadsheet or a local TSV file
+
+It allows for metadata to be downloaded at the object level
+(one spreadsheet row per parent-level digital object), or item level
+(one spreadsheet row per any item, including each component of a complex object)
+
+It also asks if all headers should be downloaded, or if properties with
+null values in Nuxeo should be excluded from the export.
+
+First written by Niqui O'Neill (UCLA Digital Library Program) in 2018.
+"""
 import os
 import unicodecsv as csv
 from pynux import utils
@@ -26,17 +33,22 @@ except:
     all_headers = input('All Headers? (Y/N): ')
 
 
-def get_title(data2, x):  #gets title
+def get_title(data2, x):
+    """gets title
+    """
     data2['Title'] = x['properties']['dc:title']
 
 
-def get_filepath(data2, x):  #gets filepath
+def get_filepath(data2, x):
+    """gets filepath
+    """
     data2['File path'] = x['path']
 
 
-def get_type(
-    data2, x, all_headers
-):  #gets type, inputs are dictionary (data2), nuxeo (x), all_headers input
+def get_type(data2, x, all_headers):
+    """gets type, 
+    inputs are dictionary (data2), nuxeo (x), all_headers input
+    """
     if x['properties']['ucldc_schema:type'] != None and x['properties'][
             'ucldc_schema:type'] != '':
         data2['Type'] = x['properties']['ucldc_schema:type']

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -53,7 +53,9 @@ def main():
     nuxeo_top_path = args.path[0].strip()
     item_level = args.item_level
     all_headers = args.all_headers
-    gsheets_url = args.sheet.strip()
+    gsheets_url = args.sheet
+    if gsheets_url:
+        gsheets_url = gsheets_url.strip()
 
     nx = utils.Nuxeo()
 

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -94,18 +94,7 @@ def process_metadata(nxdoc, all_headers):
 
     get_single_string_fields(data2, nxdoc)
     get_string_list_fields(data2, nxdoc)
-
-    get_date(data2, nxdoc, all_headers)
-
-    get_creator(data2, nxdoc, all_headers)
-    get_contributor(data2, nxdoc, all_headers)
-    get_description(data2, nxdoc, all_headers)
-    get_language(data2, nxdoc, all_headers)
-    get_copyright_holder(data2, nxdoc, all_headers)
-    get_subject_name(data2, nxdoc, all_headers)
-    get_place(data2, nxdoc, all_headers)
-    get_subject_topic(data2, nxdoc, all_headers)
-    get_form_genre(data2, nxdoc, all_headers)
+    get_dict_list_fields(data2, nxdoc)
 
     return data2
 
@@ -163,603 +152,80 @@ def get_string_list_fields(data2, nxdoc):
             num += 1
 
 
-def get_date(data2, nxdoc, all_headers):
-    datenumb = 0
-    if isinstance(nxdoc["properties"]["ucldc_schema:date"],
-                  list) and len(nxdoc["properties"]["ucldc_schema:date"]) > 0:
-        while datenumb < len(nxdoc["properties"]["ucldc_schema:date"]):
-            num = datenumb + 1
-            try:
-                name = "Date %d" % num
-                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
-                        "date"] is not None and nxdoc["properties"][
-                            "ucldc_schema:date"][datenumb]["date"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
-                        datenumb]["date"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Date %d Type" % num
-                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
-                        "datetype"] is not None and nxdoc["properties"][
-                            "ucldc_schema:date"][datenumb]["datetype"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
-                        datenumb]["datetype"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Date %d Inclusive Start" % num
-                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
-                        "inclusivestart"] is not None and nxdoc["properties"][
-                            "ucldc_schema:date"][datenumb][
-                                "inclusivestart"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
-                        datenumb]["inclusivestart"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Date %d Inclusive End" % num
-                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
-                        "inclusiveend"] is not None and nxdoc["properties"][
-                            "ucldc_schema:date"][datenumb][
-                                "inclusiveend"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
-                        datenumb]["inclusiveend"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Date %d Single" % num
-                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
-                        "single"] is not None and nxdoc["properties"][
-                            "ucldc_schema:date"][datenumb]["single"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
-                        datenumb]["single"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            datenumb += 1
-    elif all_headers:
-        data2["Date 1"] = ""
-        data2["Date 1 Type"] = ""
-        data2["Date 1 Inclusive Start"] = ""
-        data2["Date 1 Inclusive End"] = ""
-        data2["Date 1 Single"] = ""
+def get_dict_list_fields(data2, nxdoc):
+    """ map complex fields that are lists of dicts
+    """
+    complex_property_map = {
+        "ucldc_schema:date": {
+            "Date %d": "date",
+            "Date %d Type": "datetype",
+            "Date %d Inclusive Start": "inclusivestart",
+            "Date %d Inclusive End": "inclusiveend",
+            "Date %d Single": "single"
+        },
+        "ucldc_schema:creator": {
+            "Creator %d Name": "name",
+            "Creator %d Name Type": "nametype",
+            "Creator %d Role": "role",
+            "Creator %d Source": "source",
+            "Creator %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:contributor": {
+            "Contributor %d Name": "name",
+            "Contributor %d Name Type": "nametype",
+            "Contributor %d Role": "role",
+            "Contributor %d Source": "source",
+            "Contributor %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:description": {
+            "Description %d Note": "item",
+            "Description %d Type": "type"
+        },
+        "ucldc_schema:language": {
+            "Language %d": "language",
+            "Language %d Code": "languagecode"
+        },
+        "ucldc_schema:rightsholder": {
+            "Copyright Holder %d Name": "name",
+            "Copyright Holder %d Name Type": "nametype",
+            "Copyright Holder %d Role": "role",
+            "Copyright Holder %d Source": "source",
+            "Copyright Holder %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:subjectname": {
+            "Contributor %d Name": "name",
+            "Contributor %d Name Type": "nametype",
+            "Contributor %d Role": "role",
+            "Contributor %d Source": "source",
+            "Contributor %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:place": {
+            "Place %d Name": "name",
+            "Place %d Source": "source",
+            "Place %d Coordinates": "coordinates",
+            "Place %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:subjecttopic": {
+            "Subject (Topic) %d Heading": "heading",
+            "Subject (Topic) %d Heading Type": "headingtype",
+            "Subject (Topic) %d Source": "source",
+            "Subject (Topic) %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:formgenre": {
+            "Form/Genre %d Heading": "heading",
+            "Form/Genre %d Source": "source",
+            "Form/Genre %d Authority ID": "authorityid"
+        }
+    }
 
-
-def get_creator(data2, nxdoc, all_headers):
-    creatnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:creator"],
-            list) and len(nxdoc["properties"]["ucldc_schema:creator"]) > 0:
-        while creatnumb < len(nxdoc["properties"]["ucldc_schema:creator"]):
-            num = creatnumb + 1
-            try:
-                name = "Creator %d Name" % num
-                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
-                        "name"] is not None and nxdoc["properties"][
-                            "ucldc_schema:creator"][creatnumb]["name"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
-                        creatnumb]["name"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Creator %d Name Type" % num
-                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
-                        "nametype"] is not None and nxdoc["properties"][
-                            "ucldc_schema:creator"][creatnumb][
-                                "nametype"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
-                        creatnumb]["nametype"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Creator %d Role" % num
-                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
-                        "role"] is not None and nxdoc["properties"][
-                            "ucldc_schema:creator"][creatnumb]["role"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
-                        creatnumb]["role"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Creator %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
-                        "source"] is not None and nxdoc["properties"][
-                            "ucldc_schema:creator"][creatnumb]["source"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
-                        creatnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Creator %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
-                        "authorityid"] is not None and nxdoc["properties"][
-                            "ucldc_schema:creator"][creatnumb][
-                                "authorityid"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
-                        creatnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            creatnumb += 1
-    elif all_headers:
-        data2["Creator 1 Name"] = ""
-        data2["Creator 1 Name Type"] = ""
-        data2["Creator 1 Role"] = ""
-        data2["Creator 1 Source"] = ""
-        data2["Creator 1 Authority ID"] = ""
-
-
-def get_contributor(data2, nxdoc, all_headers):
-    contnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:contributor"],
-            list) and len(nxdoc["properties"]["ucldc_schema:contributor"]) > 0:
-        while contnumb < len(nxdoc["properties"]["ucldc_schema:contributor"]):
-            num = contnumb + 1
-            try:
-                name = "Contributor %d Name" % num
-                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
-                        "name"] is not None and nxdoc["properties"][
-                            "ucldc_schema:contributor"][contnumb]["name"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:contributor"][contnumb]["name"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Contributor %d Name Type" % num
-                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
-                        "nametype"] is not None and nxdoc["properties"][
-                            "ucldc_schema:contributor"][contnumb][
-                                "nametype"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:contributor"][contnumb]["nametype"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Contributor %d Role" % num
-                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
-                        "role"] is not None and nxdoc["properties"][
-                            "ucldc_schema:contributor"][contnumb]["role"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:contributor"][contnumb]["role"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Contributor %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
-                        "source"] is not None and nxdoc["properties"][
-                            "ucldc_schema:contributor"][contnumb][
-                                "source"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:contributor"][contnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Contributor %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
-                        "authorityid"] is not None and nxdoc["properties"][
-                            "ucldc_schema:contributor"][contnumb][
-                                "authorityid"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:contributor"][contnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            contnumb += 1
-    elif all_headers:
-        data2["Contributor 1 Name"] = ""
-        data2["Contributor 1 Name Type"] = ""
-        data2["Contributor 1 Role"] = ""
-        data2["Contributor 1 Source"] = ""
-        data2["Contributor 1 Authority ID"] = ""
-
-
-def get_description(data2, nxdoc, all_headers):
-    descnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:description"],
-            list) and len(nxdoc["properties"]["ucldc_schema:description"]) > 0:
-        while descnumb < len(nxdoc["properties"]["ucldc_schema:description"]):
-            num = descnumb + 1
-            try:
-                name = "Description %d Note" % num
-                if nxdoc["properties"]["ucldc_schema:description"][descnumb][
-                        "item"] is not None and nxdoc["properties"][
-                            "ucldc_schema:description"][descnumb]["item"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:description"][descnumb]["item"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Description %d Type" % num
-                if nxdoc["properties"]["ucldc_schema:description"][descnumb][
-                        "type"] is not None and nxdoc["properties"][
-                            "ucldc_schema:description"][descnumb]["type"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:description"][descnumb]["type"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            descnumb += 1
-    elif all_headers:
-        data2["Description 1 Note"] = ""
-        data2["Description 1 Type"] = ""
-
-
-def get_language(data2, nxdoc, all_headers):
-    langnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:language"],
-            list) and len(nxdoc["properties"]["ucldc_schema:language"]) > 0:
-        while langnumb < len(nxdoc["properties"]["ucldc_schema:language"]):
-            num = langnumb + 1
-            try:
-                name = "Language %d" % num
-                if nxdoc["properties"]["ucldc_schema:language"][langnumb][
-                        "language"] is not None and nxdoc["properties"][
-                            "ucldc_schema:language"][langnumb][
-                                "language"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:language"][
-                        langnumb]["language"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Language %d Code" % num
-                if nxdoc["properties"]["ucldc_schema:language"][langnumb][
-                        "languagecode"] is not None and nxdoc["properties"][
-                            "ucldc_schema:language"][langnumb][
-                                "languagecode"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:language"][
-                        langnumb]["languagecode"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            langnumb += 1
-    elif all_headers:
-        data2["Language 1"] = ""
-        data2["Language 1 Code"] = ""
-
-
-def get_copyright_holder(data2, nxdoc, all_headers):
-    rightsnumb = 0
-    if isinstance(nxdoc["properties"]["ucldc_schema:rightsholder"],
-                  list) and len(
-                      nxdoc["properties"]["ucldc_schema:rightsholder"]) > 0:
-        while rightsnumb < len(
-                nxdoc["properties"]["ucldc_schema:rightsholder"]):
-            num = rightsnumb + 1
-            try:
-                name = "Copyright Holder %d Name" % num
-                if nxdoc["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["name"] is not None and nxdoc[
-                            "properties"]["ucldc_schema:rightsholder"][
-                                rightsnumb]["name"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:rightsholder"][rightsnumb]["name"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Copyright Holder %d Name Type" % num
-                if nxdoc["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["nametype"] is not None and nxdoc[
-                            "properties"]["ucldc_schema:rightsholder"][
-                                rightsnumb]["nametype"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:rightsholder"][rightsnumb]["nametype"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Copyright Holder %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["source"] is not None and nxdoc[
-                            "properties"]["ucldc_schema:rightsholder"][
-                                rightsnumb]["source"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:rightsholder"][rightsnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Copyright Holder %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["authorityid"] is not None and nxdoc[
-                            "properties"]["ucldc_schema:rightsholder"][
-                                rightsnumb]["authorityid"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:rightsholder"][rightsnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            rightsnumb += 1
-    elif all_headers:
-        data2["Copyright Holder 1 Name"] = ""
-        data2["Copyright Holder 1 Name Type"] = ""
-        data2["Copyright Holder 1 Source"] = ""
-        data2["Copyright Holder 1 Authority ID"] = ""
-
-
-def get_subject_name(data2, nxdoc, all_headers):
-    subnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:subjectname"],
-            list) and len(nxdoc["properties"]["ucldc_schema:subjectname"]) > 0:
-        while subnumb < len(nxdoc["properties"]["ucldc_schema:subjectname"]):
-            num = subnumb + 1
-            try:
-                name = "Subject (Name) %d Name" % num
-                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "name"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjectname"][subnumb]["name"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjectname"][subnumb]["name"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Name) %d Name Type" % num
-                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "name_type"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjectname"][subnumb][
-                                "name_type"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjectname"][subnumb]["name_type"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Name) %d Role" % num
-                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "role"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjectname"][subnumb]["role"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjectname"][subnumb]["role"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Name) %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "source"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjectname"][subnumb][
-                                "source"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjectname"][subnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Name) %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "authorityid"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjectname"][subnumb][
-                                "authorityid"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjectname"][subnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            subnumb += 1
-    elif all_headers:
-        data2["Subject (Name) 1 Name"] = ""
-        data2["Subject (Name) 1 Name Type"] = ""
-        data2["Subject (Name) 1 Role"] = ""
-        data2["Subject (Name) 1 Source"] = ""
-        data2["Subject (Name) 1 Authority ID"] = ""
-
-
-def get_place(data2, nxdoc, all_headers):
-    plcnumb = 0
-    if isinstance(nxdoc["properties"]["ucldc_schema:place"],
-                  list) and len(nxdoc["properties"]["ucldc_schema:place"]) > 0:
-        while plcnumb < len(nxdoc["properties"]["ucldc_schema:place"]):
-            num = plcnumb + 1
-            try:
-                name = "Place %d Name" % num
-                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
-                        "name"] is not None and nxdoc["properties"][
-                            "ucldc_schema:place"][plcnumb]["name"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
-                        plcnumb]["name"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Place %d Coordinates" % num
-                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
-                        "coordinates"] is not None and nxdoc["properties"][
-                            "ucldc_schema:place"][plcnumb]["coordinates"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
-                        plcnumb]["coordinates"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Place %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
-                        "source"] is not None and nxdoc["properties"][
-                            "ucldc_schema:place"][plcnumb]["source"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
-                        plcnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Place %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
-                        "authorityid"] is not None and nxdoc["properties"][
-                            "ucldc_schema:place"][plcnumb]["authorityid"] != "":
-                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
-                        plcnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            plcnumb += 1
-    elif all_headers:
-        data2["Place 1 Name"] = ""
-        data2["Place 1 Coordinates"] = ""
-        data2["Place 1 Source"] = ""
-        data2["Place 1 Authority ID"] = ""
-
-
-def get_subject_topic(data2, nxdoc, all_headers):
-    topnumb = 0
-    if isinstance(nxdoc["properties"]["ucldc_schema:subjecttopic"],
-                  list) and len(
-                      nxdoc["properties"]["ucldc_schema:subjecttopic"]) > 0:
-        while topnumb < len(nxdoc["properties"]["ucldc_schema:subjecttopic"]):
-            num = topnumb + 1
-            try:
-                name = "Subject (Topic) %d Heading" % num
-                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "heading"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjecttopic"][topnumb][
-                                "heading"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjecttopic"][topnumb]["heading"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Topic) %d Heading Type" % num
-                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "headingtype"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjecttopic"][topnumb][
-                                "headingtype"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjecttopic"][topnumb]["headingtype"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Topic) %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "source"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjecttopic"][topnumb][
-                                "source"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjecttopic"][topnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Subject (Topic) %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "authorityid"] is not None and nxdoc["properties"][
-                            "ucldc_schema:subjecttopic"][topnumb][
-                                "authorityid"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:subjecttopic"][topnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            topnumb += 1
-    elif all_headers:
-        data2["Subject (Topic) 1 Heading"] = ""
-        data2["Subject (Topic) 1 Heading Type"] = ""
-        data2["Subject (Topic) 1 Source"] = ""
-        data2["Subject (Topic) 1 Authority ID"] = ""
-
-
-def get_form_genre(data2, nxdoc, all_headers):
-    formnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:formgenre"],
-            list) and len(nxdoc["properties"]["ucldc_schema:formgenre"]) > 0:
-        while formnumb < len(nxdoc["properties"]["ucldc_schema:formgenre"]):
-            num = formnumb + 1
-            try:
-                name = "Form/Genre %d Heading" % num
-                if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
-                        "heading"] is not None and nxdoc["properties"][
-                            "ucldc_schema:formgenre"][formnumb][
-                                "heading"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:formgenre"][formnumb]["heading"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Form/Genre %d Source" % num
-                if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
-                        "source"] is not None and nxdoc["properties"][
-                            "ucldc_schema:formgenre"][formnumb]["source"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:formgenre"][formnumb]["source"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            try:
-                name = "Form/Genre %d Authority ID" % num
-                if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
-                        "authorityid"] is not None and nxdoc["properties"][
-                            "ucldc_schema:formgenre"][formnumb][
-                                "authorityid"] != "":
-                    data2[name] = nxdoc["properties"][
-                        "ucldc_schema:formgenre"][formnumb]["authorityid"]
-                elif all_headers:
-                    data2[name] = ""
-            except:
-                pass
-            formnumb += 1
-    elif all_headers:
-        data2["Form/Genre 1 Heading"] = ""
-        data2["Form/Genre 1 Source"] = ""
-        data2["Form/Genre 1 Authority ID"] = ""
+    for field, subfields in complex_property_map.items():
+        num = 0
+        field_data = nxdoc["properties"].get(field)
+        while num < len(field_data):
+            for key, value in subfields.items():
+                field_label = key % (num + 1)
+                data2[field_label] = field_data[num].get(value)
+            num += 1
 
 
 def make_fieldnames(data, all_headers):

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -8,7 +8,7 @@ and saves to a local TSV file. It includes column headers
 only for properties that contain non-null and non-empty string values.
 
 Command-line options allow the choice to export to Google Sheets,
-export data at the item level (one row per item, including each 
+export data at the item level (one row per item, including each
 individual component of a complex object), or include all headers
 (including those with null/blank values)
 

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -158,8 +158,8 @@ def get_alt_title(data2, nxdoc, all_headers):
                 nxdoc["properties"]["ucldc_schema:alternativetitle"]) > 0:
         while altnumb < len(
                 nxdoc["properties"]["ucldc_schema:alternativetitle"]):
-            numb = altnumb + 1
-            name = "Alternative Title %d" % numb
+            num = altnumb + 1
+            name = "Alternative Title %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:alternativetitle"][
                 altnumb]
             altnumb += 1
@@ -182,8 +182,8 @@ def get_local_identifier(data2, nxdoc, all_headers):
                       nxdoc["properties"]["ucldc_schema:localidentifier"]) > 0:
         while locnumb < len(
                 nxdoc["properties"]["ucldc_schema:localidentifier"]):
-            numb = locnumb + 1
-            name = "Local Identifier %d" % numb
+            num = locnumb + 1
+            name = "Local Identifier %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:localidentifier"][
                 locnumb]
             locnumb += 1
@@ -197,8 +197,8 @@ def get_campus_unit(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:campusunit"],
             list) and len(nxdoc["properties"]["ucldc_schema:campusunit"]) > 0:
         while campnumb < len(nxdoc["properties"]["ucldc_schema:campusunit"]):
-            numb = campnumb + 1
-            name = "Campus/Unit %d" % numb
+            num = campnumb + 1
+            name = "Campus/Unit %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:campusunit"][
                 campnumb]
             campnumb += 1
@@ -211,9 +211,9 @@ def get_date(data2, nxdoc, all_headers):
     if isinstance(nxdoc["properties"]["ucldc_schema:date"],
                   list) and len(nxdoc["properties"]["ucldc_schema:date"]) > 0:
         while datenumb < len(nxdoc["properties"]["ucldc_schema:date"]):
-            numb = datenumb + 1
+            num = datenumb + 1
             try:
-                name = "Date %d" % numb
+                name = "Date %d" % num
                 if nxdoc["properties"]["ucldc_schema:date"][datenumb][
                         "date"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb]["date"] != "":
@@ -224,7 +224,7 @@ def get_date(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Date %d Type" % numb
+                name = "Date %d Type" % num
                 if nxdoc["properties"]["ucldc_schema:date"][datenumb][
                         "datetype"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb]["datetype"] != "":
@@ -235,7 +235,7 @@ def get_date(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Date %d Inclusive Start" % numb
+                name = "Date %d Inclusive Start" % num
                 if nxdoc["properties"]["ucldc_schema:date"][datenumb][
                         "inclusivestart"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb][
@@ -247,7 +247,7 @@ def get_date(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Date %d Inclusive End" % numb
+                name = "Date %d Inclusive End" % num
                 if nxdoc["properties"]["ucldc_schema:date"][datenumb][
                         "inclusiveend"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb][
@@ -259,7 +259,7 @@ def get_date(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Date %d Single" % numb
+                name = "Date %d Single" % num
                 if nxdoc["properties"]["ucldc_schema:date"][datenumb][
                         "single"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb]["single"] != "":
@@ -284,8 +284,8 @@ def get_publication(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:publisher"],
             list) and len(nxdoc["properties"]["ucldc_schema:publisher"]) > 0:
         while pubnumb < len(nxdoc["properties"]["ucldc_schema:publisher"]):
-            numb = pubnumb + 1
-            name = "Publication/Origination Info %d" % numb
+            num = pubnumb + 1
+            name = "Publication/Origination Info %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:publisher"][
                 pubnumb]
             pubnumb += 1
@@ -299,9 +299,9 @@ def get_creator(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:creator"],
             list) and len(nxdoc["properties"]["ucldc_schema:creator"]) > 0:
         while creatnumb < len(nxdoc["properties"]["ucldc_schema:creator"]):
-            numb = creatnumb + 1
+            num = creatnumb + 1
             try:
-                name = "Creator %d Name" % numb
+                name = "Creator %d Name" % num
                 if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
                         "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb]["name"] != "":
@@ -312,7 +312,7 @@ def get_creator(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Creator %d Name Type" % numb
+                name = "Creator %d Name Type" % num
                 if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
                         "nametype"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb][
@@ -324,7 +324,7 @@ def get_creator(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Creator %d Role" % numb
+                name = "Creator %d Role" % num
                 if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
                         "role"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb]["role"] != "":
@@ -335,7 +335,7 @@ def get_creator(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Creator %d Source" % numb
+                name = "Creator %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
                         "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb]["source"] != "":
@@ -346,7 +346,7 @@ def get_creator(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Creator %d Authority ID" % numb
+                name = "Creator %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
                         "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb][
@@ -372,9 +372,9 @@ def get_contributor(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:contributor"],
             list) and len(nxdoc["properties"]["ucldc_schema:contributor"]) > 0:
         while contnumb < len(nxdoc["properties"]["ucldc_schema:contributor"]):
-            numb = contnumb + 1
+            num = contnumb + 1
             try:
-                name = "Contributor %d Name" % numb
+                name = "Contributor %d Name" % num
                 if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
                         "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb]["name"] != "":
@@ -385,7 +385,7 @@ def get_contributor(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Contributor %d Name Type" % numb
+                name = "Contributor %d Name Type" % num
                 if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
                         "nametype"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb][
@@ -397,7 +397,7 @@ def get_contributor(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Contributor %d Role" % numb
+                name = "Contributor %d Role" % num
                 if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
                         "role"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb]["role"] != "":
@@ -408,7 +408,7 @@ def get_contributor(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Contributor %d Source" % numb
+                name = "Contributor %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
                         "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb][
@@ -420,7 +420,7 @@ def get_contributor(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Contributor %d Authority ID" % numb
+                name = "Contributor %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
                         "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb][
@@ -455,9 +455,9 @@ def get_description(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:description"],
             list) and len(nxdoc["properties"]["ucldc_schema:description"]) > 0:
         while descnumb < len(nxdoc["properties"]["ucldc_schema:description"]):
-            numb = descnumb + 1
+            num = descnumb + 1
             try:
-                name = "Description %d Note" % numb
+                name = "Description %d Note" % num
                 if nxdoc["properties"]["ucldc_schema:description"][descnumb][
                         "item"] is not None and nxdoc["properties"][
                             "ucldc_schema:description"][descnumb]["item"] != "":
@@ -468,7 +468,7 @@ def get_description(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Description %d Type" % numb
+                name = "Description %d Type" % num
                 if nxdoc["properties"]["ucldc_schema:description"][descnumb][
                         "type"] is not None and nxdoc["properties"][
                             "ucldc_schema:description"][descnumb]["type"] != "":
@@ -498,9 +498,9 @@ def get_language(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:language"],
             list) and len(nxdoc["properties"]["ucldc_schema:language"]) > 0:
         while langnumb < len(nxdoc["properties"]["ucldc_schema:language"]):
-            numb = langnumb + 1
+            num = langnumb + 1
             try:
-                name = "Language %d" % numb
+                name = "Language %d" % num
                 if nxdoc["properties"]["ucldc_schema:language"][langnumb][
                         "language"] is not None and nxdoc["properties"][
                             "ucldc_schema:language"][langnumb][
@@ -512,7 +512,7 @@ def get_language(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Language %d Code" % numb
+                name = "Language %d Code" % num
                 if nxdoc["properties"]["ucldc_schema:language"][langnumb][
                         "languagecode"] is not None and nxdoc["properties"][
                             "ucldc_schema:language"][langnumb][
@@ -537,8 +537,8 @@ def get_temporal_coverage(data2, nxdoc, all_headers):
                 nxdoc["properties"]["ucldc_schema:temporalcoverage"]) > 0:
         while tempnumb < len(
                 nxdoc["properties"]["ucldc_schema:temporalcoverage"]):
-            numb = tempnumb + 1
-            name = "Temporal Coverage %d" % numb
+            num = tempnumb + 1
+            name = "Temporal Coverage %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:temporalcoverage"][
                 tempnumb]
             tempnumb += 1
@@ -590,9 +590,9 @@ def get_copyright_holder(data2, nxdoc, all_headers):
                       nxdoc["properties"]["ucldc_schema:rightsholder"]) > 0:
         while rightsnumb < len(
                 nxdoc["properties"]["ucldc_schema:rightsholder"]):
-            numb = rightsnumb + 1
+            num = rightsnumb + 1
             try:
-                name = "Copyright Holder %d Name" % numb
+                name = "Copyright Holder %d Name" % num
                 if nxdoc["properties"]["ucldc_schema:rightsholder"][
                         rightsnumb]["name"] is not None and nxdoc[
                             "properties"]["ucldc_schema:rightsholder"][
@@ -604,7 +604,7 @@ def get_copyright_holder(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Copyright Holder %d Name Type" % numb
+                name = "Copyright Holder %d Name Type" % num
                 if nxdoc["properties"]["ucldc_schema:rightsholder"][
                         rightsnumb]["nametype"] is not None and nxdoc[
                             "properties"]["ucldc_schema:rightsholder"][
@@ -616,7 +616,7 @@ def get_copyright_holder(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Copyright Holder %d Source" % numb
+                name = "Copyright Holder %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:rightsholder"][
                         rightsnumb]["source"] is not None and nxdoc[
                             "properties"]["ucldc_schema:rightsholder"][
@@ -628,7 +628,7 @@ def get_copyright_holder(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Copyright Holder %d Authority ID" % numb
+                name = "Copyright Holder %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:rightsholder"][
                         rightsnumb]["authorityid"] is not None and nxdoc[
                             "properties"]["ucldc_schema:rightsholder"][
@@ -707,8 +707,8 @@ def get_collection(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:collection"],
             list) and len(nxdoc["properties"]["ucldc_schema:collection"]) > 0:
         while collnumb < len(nxdoc["properties"]["ucldc_schema:collection"]):
-            numb = collnumb + 1
-            name = "Collection %d" % numb
+            num = collnumb + 1
+            name = "Collection %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:collection"][
                 collnumb]
             collnumb += 1
@@ -723,8 +723,8 @@ def get_related_resource(data2, nxdoc, all_headers):
                       nxdoc["properties"]["ucldc_schema:relatedresource"]) > 0:
         while relnumb < len(
                 nxdoc["properties"]["ucldc_schema:relatedresource"]):
-            numb = relnumb + 1
-            name = "Related Resource %d" % numb
+            num = relnumb + 1
+            name = "Related Resource %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:relatedresource"][
                 relnumb]
             relnumb += 1
@@ -746,9 +746,9 @@ def get_subject_name(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:subjectname"],
             list) and len(nxdoc["properties"]["ucldc_schema:subjectname"]) > 0:
         while subnumb < len(nxdoc["properties"]["ucldc_schema:subjectname"]):
-            numb = subnumb + 1
+            num = subnumb + 1
             try:
-                name = "Subject (Name) %d Name" % numb
+                name = "Subject (Name) %d Name" % num
                 if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
                         "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb]["name"] != "":
@@ -759,7 +759,7 @@ def get_subject_name(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Name) %d Name Type" % numb
+                name = "Subject (Name) %d Name Type" % num
                 if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
                         "name_type"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb][
@@ -771,7 +771,7 @@ def get_subject_name(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Name) %d Role" % numb
+                name = "Subject (Name) %d Role" % num
                 if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
                         "role"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb]["role"] != "":
@@ -782,7 +782,7 @@ def get_subject_name(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Name) %d Source" % numb
+                name = "Subject (Name) %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
                         "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb][
@@ -794,7 +794,7 @@ def get_subject_name(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Name) %d Authority ID" % numb
+                name = "Subject (Name) %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
                         "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb][
@@ -819,9 +819,9 @@ def get_place(data2, nxdoc, all_headers):
     if isinstance(nxdoc["properties"]["ucldc_schema:place"],
                   list) and len(nxdoc["properties"]["ucldc_schema:place"]) > 0:
         while plcnumb < len(nxdoc["properties"]["ucldc_schema:place"]):
-            numb = plcnumb + 1
+            num = plcnumb + 1
             try:
-                name = "Place %d Name" % numb
+                name = "Place %d Name" % num
                 if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
                         "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["name"] != "":
@@ -832,7 +832,7 @@ def get_place(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Place %d Coordinates" % numb
+                name = "Place %d Coordinates" % num
                 if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
                         "coordinates"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["coordinates"] != "":
@@ -843,7 +843,7 @@ def get_place(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Place %d Source" % numb
+                name = "Place %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
                         "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["source"] != "":
@@ -854,7 +854,7 @@ def get_place(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Place %d Authority ID" % numb
+                name = "Place %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
                         "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["authorityid"] != "":
@@ -878,9 +878,9 @@ def get_subject_topic(data2, nxdoc, all_headers):
                   list) and len(
                       nxdoc["properties"]["ucldc_schema:subjecttopic"]) > 0:
         while topnumb < len(nxdoc["properties"]["ucldc_schema:subjecttopic"]):
-            numb = topnumb + 1
+            num = topnumb + 1
             try:
-                name = "Subject (Topic) %d Heading" % numb
+                name = "Subject (Topic) %d Heading" % num
                 if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
                         "heading"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
@@ -892,7 +892,7 @@ def get_subject_topic(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Topic) %d Heading Type" % numb
+                name = "Subject (Topic) %d Heading Type" % num
                 if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
                         "headingtype"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
@@ -904,7 +904,7 @@ def get_subject_topic(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Topic) %d Source" % numb
+                name = "Subject (Topic) %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
                         "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
@@ -916,7 +916,7 @@ def get_subject_topic(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Subject (Topic) %d Authority ID" % numb
+                name = "Subject (Topic) %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
                         "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
@@ -941,9 +941,9 @@ def get_form_genre(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:formgenre"],
             list) and len(nxdoc["properties"]["ucldc_schema:formgenre"]) > 0:
         while formnumb < len(nxdoc["properties"]["ucldc_schema:formgenre"]):
-            numb = formnumb + 1
+            num = formnumb + 1
             try:
-                name = "Form/Genre %d Heading" % numb
+                name = "Form/Genre %d Heading" % num
                 if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
                         "heading"] is not None and nxdoc["properties"][
                             "ucldc_schema:formgenre"][formnumb][
@@ -955,7 +955,7 @@ def get_form_genre(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Form/Genre %d Source" % numb
+                name = "Form/Genre %d Source" % num
                 if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
                         "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:formgenre"][formnumb]["source"] != "":
@@ -966,7 +966,7 @@ def get_form_genre(data2, nxdoc, all_headers):
             except:
                 pass
             try:
-                name = "Form/Genre %d Authority ID" % numb
+                name = "Form/Genre %d Authority ID" % num
                 if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
                         "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:formgenre"][formnumb][
@@ -990,8 +990,8 @@ def get_provenance(data2, nxdoc, all_headers):
             nxdoc["properties"]["ucldc_schema:provenance"],
             list) and len(nxdoc["properties"]["ucldc_schema:provenance"]) > 0:
         while provnumb < len(nxdoc["properties"]["ucldc_schema:provenance"]):
-            numb = provnumb + 1
-            name = "Provenance %d" % numb
+            num = provnumb + 1
+            name = "Provenance %d" % num
             data2[name] = nxdoc["properties"]["ucldc_schema:provenance"][
                 provnumb]
             provnumb += 1

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -54,7 +54,7 @@ def get_type(data2, x, all_headers):
     """gets type,
     inputs are dictionary (data2), nuxeo (x), all_headers input
     """
-    if x['properties']['ucldc_schema:type'] != None and x['properties'][
+    if x['properties']['ucldc_schema:type'] is not None and x['properties'][
             'ucldc_schema:type'] != '':
         data2['Type'] = x['properties']['ucldc_schema:type']
     elif all_headers == 'y':
@@ -77,8 +77,8 @@ def get_alt_title(data2, x, all_headers):
 
 
 def get_identifier(data2, x, all_headers):
-    if x['properties']['ucldc_schema:identifier'] != None and x['properties'][
-            'ucldc_schema:identifier'] != '':
+    if x['properties']['ucldc_schema:identifier'] is not None and x[
+            'properties']['ucldc_schema:identifier'] != '':
         data2['Identifier'] = x['properties']['ucldc_schema:identifier']
     elif all_headers == 'y':
         data2['Identifier'] = ''
@@ -122,7 +122,7 @@ def get_date(data2, x, all_headers):
             try:
                 name = 'Date %d' % numb
                 if x['properties']['ucldc_schema:date'][datenumb][
-                        'date'] != None and x['properties'][
+                        'date'] is not None and x['properties'][
                             'ucldc_schema:date'][datenumb]['date'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['date']
@@ -133,7 +133,7 @@ def get_date(data2, x, all_headers):
             try:
                 name = 'Date %d Type' % numb
                 if x['properties']['ucldc_schema:date'][datenumb][
-                        'datetype'] != None and x['properties'][
+                        'datetype'] is not None and x['properties'][
                             'ucldc_schema:date'][datenumb]['datetype'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['datetype']
@@ -144,7 +144,7 @@ def get_date(data2, x, all_headers):
             try:
                 name = 'Date %d Inclusive Start' % numb
                 if x['properties']['ucldc_schema:date'][datenumb][
-                        'inclusivestart'] != None and x['properties'][
+                        'inclusivestart'] is not None and x['properties'][
                             'ucldc_schema:date'][datenumb][
                                 'inclusivestart'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
@@ -156,7 +156,7 @@ def get_date(data2, x, all_headers):
             try:
                 name = 'Date %d Inclusive End' % numb
                 if x['properties']['ucldc_schema:date'][datenumb][
-                        'inclusiveend'] != None and x['properties'][
+                        'inclusiveend'] is not None and x['properties'][
                             'ucldc_schema:date'][datenumb][
                                 'inclusiveend'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
@@ -168,7 +168,7 @@ def get_date(data2, x, all_headers):
             try:
                 name = 'Date %d Single' % numb
                 if x['properties']['ucldc_schema:date'][datenumb][
-                        'single'] != None and x['properties'][
+                        'single'] is not None and x['properties'][
                             'ucldc_schema:date'][datenumb]['single'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['single']
@@ -207,7 +207,7 @@ def get_creator(data2, x, all_headers):
             try:
                 name = 'Creator %d Name' % numb
                 if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'name'] != None and x['properties'][
+                        'name'] is not None and x['properties'][
                             'ucldc_schema:creator'][creatnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['name']
@@ -218,7 +218,7 @@ def get_creator(data2, x, all_headers):
             try:
                 name = 'Creator %d Name Type' % numb
                 if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'nametype'] != None and x['properties'][
+                        'nametype'] is not None and x['properties'][
                             'ucldc_schema:creator'][creatnumb][
                                 'nametype'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
@@ -230,7 +230,7 @@ def get_creator(data2, x, all_headers):
             try:
                 name = 'Creator %d Role' % numb
                 if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'role'] != None and x['properties'][
+                        'role'] is not None and x['properties'][
                             'ucldc_schema:creator'][creatnumb]['role'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['role']
@@ -241,7 +241,7 @@ def get_creator(data2, x, all_headers):
             try:
                 name = 'Creator %d Source' % numb
                 if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:creator'][creatnumb]['source'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['source']
@@ -252,7 +252,7 @@ def get_creator(data2, x, all_headers):
             try:
                 name = 'Creator %d Authority ID' % numb
                 if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:creator'][creatnumb][
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
@@ -280,7 +280,7 @@ def get_contributor(data2, x, all_headers):
             try:
                 name = 'Contributor %d Name' % numb
                 if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'name'] != None and x['properties'][
+                        'name'] is not None and x['properties'][
                             'ucldc_schema:contributor'][contnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['name']
@@ -291,7 +291,7 @@ def get_contributor(data2, x, all_headers):
             try:
                 name = 'Contributor %d Name Type' % numb
                 if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'nametype'] != None and x['properties'][
+                        'nametype'] is not None and x['properties'][
                             'ucldc_schema:contributor'][contnumb][
                                 'nametype'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
@@ -303,7 +303,7 @@ def get_contributor(data2, x, all_headers):
             try:
                 name = 'Contributor %d Role' % numb
                 if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'role'] != None and x['properties'][
+                        'role'] is not None and x['properties'][
                             'ucldc_schema:contributor'][contnumb]['role'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['role']
@@ -314,7 +314,7 @@ def get_contributor(data2, x, all_headers):
             try:
                 name = 'Contributor %d Source' % numb
                 if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:contributor'][contnumb][
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
@@ -326,7 +326,7 @@ def get_contributor(data2, x, all_headers):
             try:
                 name = 'Contributor %d Authority ID' % numb
                 if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:contributor'][contnumb][
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
@@ -345,8 +345,8 @@ def get_contributor(data2, x, all_headers):
 
 
 def get_format(data2, x, all_headers):
-    if x['properties']['ucldc_schema:physdesc'] != None and x['properties'][
-            'ucldc_schema:physdesc'] != '':
+    if x['properties']['ucldc_schema:physdesc'] is not None and x[
+            'properties']['ucldc_schema:physdesc'] != '':
         data2['Format/Physical Description'] = x['properties'][
             'ucldc_schema:physdesc']
     elif all_headers == 'y':
@@ -363,7 +363,7 @@ def get_description(data2, x, all_headers):
             try:
                 name = "Description %d Note" % numb
                 if x['properties']['ucldc_schema:description'][descnumb][
-                        'item'] != None and x['properties'][
+                        'item'] is not None and x['properties'][
                             'ucldc_schema:description'][descnumb]['item'] != '':
                     data2[name] = x['properties']['ucldc_schema:description'][
                         descnumb]['item']
@@ -374,7 +374,7 @@ def get_description(data2, x, all_headers):
             try:
                 name = "Description %d Type" % numb
                 if x['properties']['ucldc_schema:description'][descnumb][
-                        'type'] != None and x['properties'][
+                        'type'] is not None and x['properties'][
                             'ucldc_schema:description'][descnumb]['type'] != '':
                     data2[name] = x['properties']['ucldc_schema:description'][
                         descnumb]['type']
@@ -389,7 +389,7 @@ def get_description(data2, x, all_headers):
 
 
 def get_extent(data2, x, all_headers):
-    if x['properties']['ucldc_schema:extent'] != None and x['properties'][
+    if x['properties']['ucldc_schema:extent'] is not None and x['properties'][
             'ucldc_schema:extent'] != '':
         data2['Extent'] = x['properties']['ucldc_schema:extent']
     elif all_headers == 'y':
@@ -405,7 +405,7 @@ def get_language(data2, x, all_headers):
             try:
                 name = "Language %d" % numb
                 if x['properties']['ucldc_schema:language'][langnumb][
-                        'language'] != None and x['properties'][
+                        'language'] is not None and x['properties'][
                             'ucldc_schema:language'][langnumb][
                                 'language'] != '':
                     data2[name] = x['properties']['ucldc_schema:language'][
@@ -417,7 +417,7 @@ def get_language(data2, x, all_headers):
             try:
                 name = "Language %d Code" % numb
                 if x['properties']['ucldc_schema:language'][langnumb][
-                        'languagecode'] != None and x['properties'][
+                        'languagecode'] is not None and x['properties'][
                             'ucldc_schema:language'][langnumb][
                                 'languagecode'] != '':
                     data2[name] = x['properties']['ucldc_schema:language'][
@@ -448,7 +448,7 @@ def get_temporal_coverage(data2, x, all_headers):
 
 
 def get_transcription(data2, x, all_headers):
-    if x['properties']['ucldc_schema:transcription'] != None and x[
+    if x['properties']['ucldc_schema:transcription'] is not None and x[
             'properties']['ucldc_schema:transcription'] != '':
         data2['Transcription'] = x['properties']['ucldc_schema:transcription']
     elif all_headers == 'y':
@@ -456,7 +456,7 @@ def get_transcription(data2, x, all_headers):
 
 
 def get_access_restrictions(data2, x, all_headers):
-    if x['properties']['ucldc_schema:accessrestrict'] != None and x[
+    if x['properties']['ucldc_schema:accessrestrict'] is not None and x[
             'properties']['ucldc_schema:accessrestrict'] != '':
         data2['Access Restrictions'] = x['properties'][
             'ucldc_schema:accessrestrict']
@@ -465,7 +465,7 @@ def get_access_restrictions(data2, x, all_headers):
 
 
 def get_rights_statement(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightsstatement'] != None and x[
+    if x['properties']['ucldc_schema:rightsstatement'] is not None and x[
             'properties']['ucldc_schema:rightsstatement'] != '':
         data2['Copyright Statement'] = x['properties'][
             'ucldc_schema:rightsstatement']
@@ -474,7 +474,7 @@ def get_rights_statement(data2, x, all_headers):
 
 
 def get_rights_status(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightsstatus'] != None and x[
+    if x['properties']['ucldc_schema:rightsstatus'] is not None and x[
             'properties']['ucldc_schema:rightsstatus'] != '':
         data2['Copyright Status'] = x['properties'][
             'ucldc_schema:rightsstatus']
@@ -492,7 +492,7 @@ def get_copyright_holder(data2, x, all_headers):
             try:
                 name = 'Copyright Holder %d Name' % numb
                 if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'name'] != None and x['properties'][
+                        'name'] is not None and x['properties'][
                             'ucldc_schema:rightsholder'][rightsnumb][
                                 'name'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
@@ -504,7 +504,7 @@ def get_copyright_holder(data2, x, all_headers):
             try:
                 name = 'Copyright Holder %d Name Type' % numb
                 if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'nametype'] != None and x['properties'][
+                        'nametype'] is not None and x['properties'][
                             'ucldc_schema:rightsholder'][rightsnumb][
                                 'nametype'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
@@ -516,7 +516,7 @@ def get_copyright_holder(data2, x, all_headers):
             try:
                 name = 'Copyright Holder %d Source' % numb
                 if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:rightsholder'][rightsnumb][
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
@@ -528,7 +528,7 @@ def get_copyright_holder(data2, x, all_headers):
             try:
                 name = 'Copyright Holder %d Authority ID' % numb
                 if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:rightsholder'][rightsnumb][
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
@@ -546,50 +546,51 @@ def get_copyright_holder(data2, x, all_headers):
 
 
 def get_copyright_info(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightscontact'] != None and x[
+    if x['properties']['ucldc_schema:rightscontact'] is not None and x[
             'properties']['ucldc_schema:rightscontact'] != '':
         data2['Copyright Contact'] = x['properties'][
             'ucldc_schema:rightscontact']
     elif all_headers == 'y':
         data2['Copyright Contact'] = ''
 
-    if x['properties']['ucldc_schema:rightsnotice'] != None and x[
+    if x['properties']['ucldc_schema:rightsnotice'] is not None and x[
             'properties']['ucldc_schema:rightsnotice'] != '':
         data2['Copyright Notice'] = x['properties'][
             'ucldc_schema:rightsnotice']
     elif all_headers == 'y':
         data2['Copyright Notice'] = ''
 
-    if x['properties']['ucldc_schema:rightsdeterminationdate'] != None and x[
-            'properties']['ucldc_schema:rightsdeterminationdate'] != '':
+    if x['properties'][
+            'ucldc_schema:rightsdeterminationdate'] is not None and x[
+                'properties']['ucldc_schema:rightsdeterminationdate'] != '':
         data2['Copyright Determination Date'] = x['properties'][
             'ucldc_schema:rightsdeterminationdate']
     elif all_headers == 'y':
         data2['Copyright Determination Date'] = ''
 
-    if x['properties']['ucldc_schema:rightsstartdate'] != None and x[
+    if x['properties']['ucldc_schema:rightsstartdate'] is not None and x[
             'properties']['ucldc_schema:rightsstartdate'] != '':
         data2['Copyright Start Date'] = x['properties'][
             'ucldc_schema:rightsstartdate']
     elif all_headers == 'y':
         data2['Copyright Start Date'] = ''
 
-    if x['properties']['ucldc_schema:rightsenddate'] != None and x[
+    if x['properties']['ucldc_schema:rightsenddate'] is not None and x[
             'properties']['ucldc_schema:rightsenddate'] != '':
         data2['Copyright End Date'] = x['properties'][
             'ucldc_schema:rightsenddate']
     elif all_headers == 'y':
         data2['Copyright End Date'] = ''
 
-    if x['properties']['ucldc_schema:rightsjurisdiction'] != None and x[
+    if x['properties']['ucldc_schema:rightsjurisdiction'] is not None and x[
             'properties']['ucldc_schema:rightsjurisdiction'] != '':
         data2['Copyright Jurisdiction'] = x['properties'][
             'ucldc_schema:rightsjurisdiction']
     elif all_headers == 'y':
         data2['Copyright Jurisdiction'] = ''
 
-    if x['properties']['ucldc_schema:rightsnote'] != None and x['properties'][
-            'ucldc_schema:rightsnote'] != '':
+    if x['properties']['ucldc_schema:rightsnote'] is not None and x[
+            'properties']['ucldc_schema:rightsnote'] != '':
         data2['Copyright Note'] = x['properties']['ucldc_schema:rightsnote']
     elif all_headers == 'y':
         data2['Copyright Note'] = ''
@@ -625,7 +626,7 @@ def get_related_resource(data2, x, all_headers):
 
 
 def get_source(data2, x, all_headers):
-    if x['properties']['ucldc_schema:source'] != None and x['properties'][
+    if x['properties']['ucldc_schema:source'] is not None and x['properties'][
             'ucldc_schema:source'] != '':
         data2['Source'] = x['properties']['ucldc_schema:source']
     elif all_headers == 'y':
@@ -642,7 +643,7 @@ def get_subject_name(data2, x, all_headers):
             try:
                 name = 'Subject (Name) %d Name' % numb
                 if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'name'] != None and x['properties'][
+                        'name'] is not None and x['properties'][
                             'ucldc_schema:subjectname'][subnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['name']
@@ -653,7 +654,7 @@ def get_subject_name(data2, x, all_headers):
             try:
                 name = 'Subject (Name) %d Name Type' % numb
                 if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'name_type'] != None and x['properties'][
+                        'name_type'] is not None and x['properties'][
                             'ucldc_schema:subjectname'][subnumb][
                                 'name_type'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
@@ -665,7 +666,7 @@ def get_subject_name(data2, x, all_headers):
             try:
                 name = 'Subject (Name) %d Role' % numb
                 if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'role'] != None and x['properties'][
+                        'role'] is not None and x['properties'][
                             'ucldc_schema:subjectname'][subnumb]['role'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['role']
@@ -676,7 +677,7 @@ def get_subject_name(data2, x, all_headers):
             try:
                 name = 'Subject (Name) %d Source' % numb
                 if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:subjectname'][subnumb][
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
@@ -688,7 +689,7 @@ def get_subject_name(data2, x, all_headers):
             try:
                 name = 'Subject (Name) %d Authority ID' % numb
                 if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:subjectname'][subnumb][
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
@@ -715,7 +716,7 @@ def get_place(data2, x, all_headers):
             try:
                 name = 'Place %d Name' % numb
                 if x['properties']['ucldc_schema:place'][plcnumb][
-                        'name'] != None and x['properties'][
+                        'name'] is not None and x['properties'][
                             'ucldc_schema:place'][plcnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['name']
@@ -726,7 +727,7 @@ def get_place(data2, x, all_headers):
             try:
                 name = 'Place %d Coordinates' % numb
                 if x['properties']['ucldc_schema:place'][plcnumb][
-                        'coordinates'] != None and x['properties'][
+                        'coordinates'] is not None and x['properties'][
                             'ucldc_schema:place'][plcnumb]['coordinates'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['coordinates']
@@ -737,7 +738,7 @@ def get_place(data2, x, all_headers):
             try:
                 name = 'Place %d Source' % numb
                 if x['properties']['ucldc_schema:place'][plcnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:place'][plcnumb]['source'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['source']
@@ -748,7 +749,7 @@ def get_place(data2, x, all_headers):
             try:
                 name = 'Place %d Authority ID' % numb
                 if x['properties']['ucldc_schema:place'][plcnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:place'][plcnumb]['authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['authorityid']
@@ -774,7 +775,7 @@ def get_subject_topic(data2, x, all_headers):
             try:
                 name = 'Subject (Topic) %d Heading' % numb
                 if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'heading'] != None and x['properties'][
+                        'heading'] is not None and x['properties'][
                             'ucldc_schema:subjecttopic'][topnumb][
                                 'heading'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
@@ -786,7 +787,7 @@ def get_subject_topic(data2, x, all_headers):
             try:
                 name = 'Subject (Topic) %d Heading Type' % numb
                 if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'headingtype'] != None and x['properties'][
+                        'headingtype'] is not None and x['properties'][
                             'ucldc_schema:subjecttopic'][topnumb][
                                 'headingtype'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
@@ -798,7 +799,7 @@ def get_subject_topic(data2, x, all_headers):
             try:
                 name = 'Subject (Topic) %d Source' % numb
                 if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:subjecttopic'][topnumb][
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
@@ -810,7 +811,7 @@ def get_subject_topic(data2, x, all_headers):
             try:
                 name = 'Subject (Topic) %d Authority ID' % numb
                 if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:subjecttopic'][topnumb][
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
@@ -836,7 +837,7 @@ def get_form_genre(data2, x, all_headers):
             try:
                 name = 'Form/Genre %d Heading' % numb
                 if x['properties']['ucldc_schema:formgenre'][formnumb][
-                        'heading'] != None and x['properties'][
+                        'heading'] is not None and x['properties'][
                             'ucldc_schema:formgenre'][formnumb][
                                 'heading'] != '':
                     data2[name] = x['properties']['ucldc_schema:formgenre'][
@@ -848,7 +849,7 @@ def get_form_genre(data2, x, all_headers):
             try:
                 name = 'Form/Genre %d Source' % numb
                 if x['properties']['ucldc_schema:formgenre'][formnumb][
-                        'source'] != None and x['properties'][
+                        'source'] is not None and x['properties'][
                             'ucldc_schema:formgenre'][formnumb]['source'] != '':
                     data2[name] = x['properties']['ucldc_schema:formgenre'][
                         formnumb]['source']
@@ -859,7 +860,7 @@ def get_form_genre(data2, x, all_headers):
             try:
                 name = 'Form/Genre %d Authority ID' % numb
                 if x['properties']['ucldc_schema:formgenre'][formnumb][
-                        'authorityid'] != None and x['properties'][
+                        'authorityid'] is not None and x['properties'][
                             'ucldc_schema:formgenre'][formnumb][
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:formgenre'][
@@ -890,7 +891,7 @@ def get_provenance(data2, x, all_headers):
 
 
 def get_physical_location(data2, x, all_headers):
-    if x['properties']['ucldc_schema:physlocation'] != None and x[
+    if x['properties']['ucldc_schema:physlocation'] is not None and x[
             'properties']['ucldc_schema:physlocation'] != '':
         data2['Physical Location'] = x['properties'][
             'ucldc_schema:physlocation']

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -68,11 +68,11 @@ def main():
     if item_level:
         for obj in nx.children(nuxeo_top_path):
             for item in nx.children(obj["path"]):
-                metadata_row = process_metadata(item, all_headers)
+                metadata_row = process_metadata(item)
                 data.append(metadata_row)
     else:
         for obj in nx.children(nuxeo_top_path):
-            metadata_row = process_metadata(obj, all_headers)
+            metadata_row = process_metadata(obj)
             data.append(metadata_row)
 
     fieldnames = make_fieldnames(data, all_headers)
@@ -86,7 +86,7 @@ def main():
         write_csv(data, sheet_name, fieldnames, delimiter="\t")
 
 
-def process_metadata(nxdoc, all_headers):
+def process_metadata(nxdoc):
     """ map Nuxeo JSON to flat data structure with human-readable labels
     """
 
@@ -287,10 +287,11 @@ def write_gsheet(data, sheet_name, fieldnames, gsheets_url):
     creds = ServiceAccountCredentials.from_json_keyfile_name(
         "client_secret.json", scope)
     client = gspread.authorize(creds)
-    with open(temp, encoding="utf8") as f:  #opens and reads temporary csv file
-        s = f.read() + "\n"
+    with open(temp,
+              encoding="utf8") as infile:  #opens and reads temporary csv file
+        data = infile.read() + "\n"
     sheet_id = client.open_by_url(gsheets_url).id
-    client.import_csv(sheet_id, s)  #writes csv file to google sheet
+    client.import_csv(sheet_id, data)  #writes csv file to google sheet
     client.open_by_key(sheet_id).sheet1.update_title(sheet_name)
     os.remove(temp)  #removes temporary csv
 

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -23,28 +23,28 @@ from pynux import utils
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('path',
+    parser.add_argument("path",
                         nargs=1,
                         type=str,
                         help="Nuxeo file path to export metadata from")
 
     parser.add_argument(
-        '--item-level',
-        action='store_true',
+        "--item-level",
+        action="store_true",
         help=
-        'export data for all items, including component items of complex objects.'
+        "export data for all items, including component items of complex objects."
     )
 
     parser.add_argument(
-        '--all-headers',
-        action='store_true',
-        help='export data with all headers, even if values are blank')
+        "--all-headers",
+        action="store_true",
+        help="export data with all headers, even if values are blank")
 
-    parser.add_argument('-s',
-                        '--sheet',
+    parser.add_argument("-s",
+                        "--sheet",
                         type=str,
                         required=False,
-                        help='Google Sheets destination URL')
+                        help="Google Sheets destination URL")
 
     args = parser.parse_args()
 
@@ -63,12 +63,12 @@ def main():
                       "with API key email address")
         else:
             item = item_level(nuxeo_top_path, all_headers)
-            with open(item['filename'], "wb") as csvfile:
+            with open(item["filename"], "wb") as csvfile:
                 writer = csv.DictWriter(csvfile,
-                                        fieldnames=item['fieldnames'],
+                                        fieldnames=item["fieldnames"],
                                         delimiter="\t")
                 writer.writeheader()
-                for row in item['data']:
+                for row in item["data"]:
                     writer.writerow(row)
 
     else:
@@ -81,874 +81,874 @@ def main():
                       "with API key email address")
         else:
             obj = object_level(nuxeo_top_path, all_headers)
-            with open(obj['filename'], "wb") as csvfile:
+            with open(obj["filename"], "wb") as csvfile:
                 writer = csv.DictWriter(csvfile,
-                                        fieldnames=obj['fieldnames'],
+                                        fieldnames=obj["fieldnames"],
                                         delimiter="\t")
                 writer.writeheader()
-                for row in obj['data']:
+                for row in obj["data"]:
                     writer.writerow(row)
 
 
 def get_title(data2, x):
     """gets title
     """
-    data2['Title'] = x['properties']['dc:title']
+    data2["Title"] = x["properties"]["dc:title"]
 
 
 def get_filepath(data2, x):
     """gets filepath
     """
-    data2['File path'] = x['path']
+    data2["File path"] = x["path"]
 
 
 def get_type(data2, x, all_headers):
     """gets type,
     inputs are dictionary (data2), nuxeo (x), all_headers input
     """
-    if x['properties']['ucldc_schema:type'] is not None and x['properties'][
-            'ucldc_schema:type'] != '':
-        data2['Type'] = x['properties']['ucldc_schema:type']
-    elif all_headers == 'y':
-        data2['Type'] = ''
+    if x["properties"]["ucldc_schema:type"] is not None and x["properties"][
+            "ucldc_schema:type"] != "":
+        data2["Type"] = x["properties"]["ucldc_schema:type"]
+    elif all_headers == "y":
+        data2["Type"] = ""
 
 
 def get_alt_title(data2, x, all_headers):
     altnumb = 0
-    if isinstance(x['properties']['ucldc_schema:alternativetitle'],
+    if isinstance(x["properties"]["ucldc_schema:alternativetitle"],
                   list) and len(
-                      x['properties']['ucldc_schema:alternativetitle']) > 0:
-        while altnumb < len(x['properties']['ucldc_schema:alternativetitle']):
+                      x["properties"]["ucldc_schema:alternativetitle"]) > 0:
+        while altnumb < len(x["properties"]["ucldc_schema:alternativetitle"]):
             numb = altnumb + 1
-            name = 'Alternative Title %d' % numb
-            data2[name] = x['properties']['ucldc_schema:alternativetitle'][
+            name = "Alternative Title %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:alternativetitle"][
                 altnumb]
             altnumb += 1
-    elif all_headers == 'y':
-        data2['Alternative Title 1'] = ''
+    elif all_headers == "y":
+        data2["Alternative Title 1"] = ""
 
 
 def get_identifier(data2, x, all_headers):
-    if x['properties']['ucldc_schema:identifier'] is not None and x[
-            'properties']['ucldc_schema:identifier'] != '':
-        data2['Identifier'] = x['properties']['ucldc_schema:identifier']
-    elif all_headers == 'y':
-        data2['Identifier'] = ''
+    if x["properties"]["ucldc_schema:identifier"] is not None and x[
+            "properties"]["ucldc_schema:identifier"] != "":
+        data2["Identifier"] = x["properties"]["ucldc_schema:identifier"]
+    elif all_headers == "y":
+        data2["Identifier"] = ""
 
 
 def get_local_identifier(data2, x, all_headers):
     locnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:localidentifier'],
-            list) and len(x['properties']['ucldc_schema:localidentifier']) > 0:
-        while locnumb < len(x['properties']['ucldc_schema:localidentifier']):
+            x["properties"]["ucldc_schema:localidentifier"],
+            list) and len(x["properties"]["ucldc_schema:localidentifier"]) > 0:
+        while locnumb < len(x["properties"]["ucldc_schema:localidentifier"]):
             numb = locnumb + 1
-            name = 'Local Identifier %d' % numb
-            data2[name] = x['properties']['ucldc_schema:localidentifier'][
+            name = "Local Identifier %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:localidentifier"][
                 locnumb]
             locnumb += 1
-    elif all_headers == 'y':
-        data2['Local Identifier 1'] = ''
+    elif all_headers == "y":
+        data2["Local Identifier 1"] = ""
 
 
 def get_campus_unit(data2, x, all_headers):
     campnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:campusunit'],
-            list) and len(x['properties']['ucldc_schema:campusunit']) > 0:
-        while campnumb < len(x['properties']['ucldc_schema:campusunit']):
+            x["properties"]["ucldc_schema:campusunit"],
+            list) and len(x["properties"]["ucldc_schema:campusunit"]) > 0:
+        while campnumb < len(x["properties"]["ucldc_schema:campusunit"]):
             numb = campnumb + 1
-            name = 'Campus/Unit %d' % numb
-            data2[name] = x['properties']['ucldc_schema:campusunit'][campnumb]
+            name = "Campus/Unit %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:campusunit"][campnumb]
             campnumb += 1
-    elif all_headers == 'y':
-        data2['Campus/Unit 1'] = ''
+    elif all_headers == "y":
+        data2["Campus/Unit 1"] = ""
 
 
 def get_date(data2, x, all_headers):
     datenumb = 0
-    if isinstance(x['properties']['ucldc_schema:date'],
-                  list) and len(x['properties']['ucldc_schema:date']) > 0:
-        while datenumb < len(x['properties']['ucldc_schema:date']):
+    if isinstance(x["properties"]["ucldc_schema:date"],
+                  list) and len(x["properties"]["ucldc_schema:date"]) > 0:
+        while datenumb < len(x["properties"]["ucldc_schema:date"]):
             numb = datenumb + 1
             try:
-                name = 'Date %d' % numb
-                if x['properties']['ucldc_schema:date'][datenumb][
-                        'date'] is not None and x['properties'][
-                            'ucldc_schema:date'][datenumb]['date'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][
-                        datenumb]['date']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Date %d" % numb
+                if x["properties"]["ucldc_schema:date"][datenumb][
+                        "date"] is not None and x["properties"][
+                            "ucldc_schema:date"][datenumb]["date"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:date"][
+                        datenumb]["date"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Date %d Type' % numb
-                if x['properties']['ucldc_schema:date'][datenumb][
-                        'datetype'] is not None and x['properties'][
-                            'ucldc_schema:date'][datenumb]['datetype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][
-                        datenumb]['datetype']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Date %d Type" % numb
+                if x["properties"]["ucldc_schema:date"][datenumb][
+                        "datetype"] is not None and x["properties"][
+                            "ucldc_schema:date"][datenumb]["datetype"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:date"][
+                        datenumb]["datetype"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Date %d Inclusive Start' % numb
-                if x['properties']['ucldc_schema:date'][datenumb][
-                        'inclusivestart'] is not None and x['properties'][
-                            'ucldc_schema:date'][datenumb][
-                                'inclusivestart'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][
-                        datenumb]['inclusivestart']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Date %d Inclusive Start" % numb
+                if x["properties"]["ucldc_schema:date"][datenumb][
+                        "inclusivestart"] is not None and x["properties"][
+                            "ucldc_schema:date"][datenumb][
+                                "inclusivestart"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:date"][
+                        datenumb]["inclusivestart"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Date %d Inclusive End' % numb
-                if x['properties']['ucldc_schema:date'][datenumb][
-                        'inclusiveend'] is not None and x['properties'][
-                            'ucldc_schema:date'][datenumb][
-                                'inclusiveend'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][
-                        datenumb]['inclusiveend']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Date %d Inclusive End" % numb
+                if x["properties"]["ucldc_schema:date"][datenumb][
+                        "inclusiveend"] is not None and x["properties"][
+                            "ucldc_schema:date"][datenumb][
+                                "inclusiveend"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:date"][
+                        datenumb]["inclusiveend"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Date %d Single' % numb
-                if x['properties']['ucldc_schema:date'][datenumb][
-                        'single'] is not None and x['properties'][
-                            'ucldc_schema:date'][datenumb]['single'] != '':
-                    data2[name] = x['properties']['ucldc_schema:date'][
-                        datenumb]['single']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Date %d Single" % numb
+                if x["properties"]["ucldc_schema:date"][datenumb][
+                        "single"] is not None and x["properties"][
+                            "ucldc_schema:date"][datenumb]["single"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:date"][
+                        datenumb]["single"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             datenumb += 1
-    elif all_headers == 'y':
-        data2['Date 1'] = ''
-        data2['Date 1 Type'] = ''
-        data2['Date 1 Inclusive Start'] = ''
-        data2['Date 1 Inclusive End'] = ''
-        data2['Date 1 Single'] = ''
+    elif all_headers == "y":
+        data2["Date 1"] = ""
+        data2["Date 1 Type"] = ""
+        data2["Date 1 Inclusive Start"] = ""
+        data2["Date 1 Inclusive End"] = ""
+        data2["Date 1 Single"] = ""
 
 
 def get_publication(data2, x, all_headers):
     pubnumb = 0
-    if isinstance(x['properties']['ucldc_schema:publisher'],
-                  list) and len(x['properties']['ucldc_schema:publisher']) > 0:
-        while pubnumb < len(x['properties']['ucldc_schema:publisher']):
+    if isinstance(x["properties"]["ucldc_schema:publisher"],
+                  list) and len(x["properties"]["ucldc_schema:publisher"]) > 0:
+        while pubnumb < len(x["properties"]["ucldc_schema:publisher"]):
             numb = pubnumb + 1
-            name = 'Publication/Origination Info %d' % numb
-            data2[name] = x['properties']['ucldc_schema:publisher'][pubnumb]
+            name = "Publication/Origination Info %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:publisher"][pubnumb]
             pubnumb += 1
-    elif all_headers == 'y':
-        data2['Publication/Origination Info 1'] = ''
+    elif all_headers == "y":
+        data2["Publication/Origination Info 1"] = ""
 
 
 def get_creator(data2, x, all_headers):
     creatnumb = 0
-    if isinstance(x['properties']['ucldc_schema:creator'],
-                  list) and len(x['properties']['ucldc_schema:creator']) > 0:
-        while creatnumb < len(x['properties']['ucldc_schema:creator']):
+    if isinstance(x["properties"]["ucldc_schema:creator"],
+                  list) and len(x["properties"]["ucldc_schema:creator"]) > 0:
+        while creatnumb < len(x["properties"]["ucldc_schema:creator"]):
             numb = creatnumb + 1
             try:
-                name = 'Creator %d Name' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'name'] is not None and x['properties'][
-                            'ucldc_schema:creator'][creatnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][
-                        creatnumb]['name']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Creator %d Name" % numb
+                if x["properties"]["ucldc_schema:creator"][creatnumb][
+                        "name"] is not None and x["properties"][
+                            "ucldc_schema:creator"][creatnumb]["name"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                        creatnumb]["name"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Creator %d Name Type' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'nametype'] is not None and x['properties'][
-                            'ucldc_schema:creator'][creatnumb][
-                                'nametype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][
-                        creatnumb]['nametype']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Creator %d Name Type" % numb
+                if x["properties"]["ucldc_schema:creator"][creatnumb][
+                        "nametype"] is not None and x["properties"][
+                            "ucldc_schema:creator"][creatnumb][
+                                "nametype"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                        creatnumb]["nametype"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Creator %d Role' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'role'] is not None and x['properties'][
-                            'ucldc_schema:creator'][creatnumb]['role'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][
-                        creatnumb]['role']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Creator %d Role" % numb
+                if x["properties"]["ucldc_schema:creator"][creatnumb][
+                        "role"] is not None and x["properties"][
+                            "ucldc_schema:creator"][creatnumb]["role"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                        creatnumb]["role"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Creator %d Source' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:creator'][creatnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][
-                        creatnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Creator %d Source" % numb
+                if x["properties"]["ucldc_schema:creator"][creatnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:creator"][creatnumb]["source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                        creatnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Creator %d Authority ID' % numb
-                if x['properties']['ucldc_schema:creator'][creatnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:creator'][creatnumb][
-                                'authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:creator'][
-                        creatnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Creator %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:creator"][creatnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:creator"][creatnumb][
+                                "authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                        creatnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             creatnumb += 1
-    elif all_headers == 'y':
-        data2['Creator 1 Name'] = ''
-        data2['Creator 1 Name Type'] = ''
-        data2['Creator 1 Role'] = ''
-        data2['Creator 1 Source'] = ''
-        data2['Creator 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Creator 1 Name"] = ""
+        data2["Creator 1 Name Type"] = ""
+        data2["Creator 1 Role"] = ""
+        data2["Creator 1 Source"] = ""
+        data2["Creator 1 Authority ID"] = ""
 
 
 def get_contributor(data2, x, all_headers):
     contnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:contributor'],
-            list) and len(x['properties']['ucldc_schema:contributor']) > 0:
-        while contnumb < len(x['properties']['ucldc_schema:contributor']):
+            x["properties"]["ucldc_schema:contributor"],
+            list) and len(x["properties"]["ucldc_schema:contributor"]) > 0:
+        while contnumb < len(x["properties"]["ucldc_schema:contributor"]):
             numb = contnumb + 1
             try:
-                name = 'Contributor %d Name' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'name'] is not None and x['properties'][
-                            'ucldc_schema:contributor'][contnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][
-                        contnumb]['name']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Contributor %d Name" % numb
+                if x["properties"]["ucldc_schema:contributor"][contnumb][
+                        "name"] is not None and x["properties"][
+                            "ucldc_schema:contributor"][contnumb]["name"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:contributor"][
+                        contnumb]["name"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Contributor %d Name Type' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'nametype'] is not None and x['properties'][
-                            'ucldc_schema:contributor'][contnumb][
-                                'nametype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][
-                        contnumb]['nametype']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Contributor %d Name Type" % numb
+                if x["properties"]["ucldc_schema:contributor"][contnumb][
+                        "nametype"] is not None and x["properties"][
+                            "ucldc_schema:contributor"][contnumb][
+                                "nametype"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:contributor"][
+                        contnumb]["nametype"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Contributor %d Role' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'role'] is not None and x['properties'][
-                            'ucldc_schema:contributor'][contnumb]['role'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][
-                        contnumb]['role']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Contributor %d Role" % numb
+                if x["properties"]["ucldc_schema:contributor"][contnumb][
+                        "role"] is not None and x["properties"][
+                            "ucldc_schema:contributor"][contnumb]["role"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:contributor"][
+                        contnumb]["role"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Contributor %d Source' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:contributor'][contnumb][
-                                'source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][
-                        contnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Contributor %d Source" % numb
+                if x["properties"]["ucldc_schema:contributor"][contnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:contributor"][contnumb][
+                                "source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:contributor"][
+                        contnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Contributor %d Authority ID' % numb
-                if x['properties']['ucldc_schema:contributor'][contnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:contributor'][contnumb][
-                                'authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:contributor'][
-                        contnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Contributor %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:contributor"][contnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:contributor"][contnumb][
+                                "authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:contributor"][
+                        contnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             contnumb += 1
-    elif all_headers == 'y':
-        data2['Contributor 1 Name'] = ''
-        data2['Contributor 1 Name Type'] = ''
-        data2['Contributor 1 Role'] = ''
-        data2['Contributor 1 Source'] = ''
-        data2['Contributor 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Contributor 1 Name"] = ""
+        data2["Contributor 1 Name Type"] = ""
+        data2["Contributor 1 Role"] = ""
+        data2["Contributor 1 Source"] = ""
+        data2["Contributor 1 Authority ID"] = ""
 
 
 def get_format(data2, x, all_headers):
-    if x['properties']['ucldc_schema:physdesc'] is not None and x[
-            'properties']['ucldc_schema:physdesc'] != '':
-        data2['Format/Physical Description'] = x['properties'][
-            'ucldc_schema:physdesc']
-    elif all_headers == 'y':
-        data2['Format/Physical Description'] = ''
+    if x["properties"]["ucldc_schema:physdesc"] is not None and x[
+            "properties"]["ucldc_schema:physdesc"] != "":
+        data2["Format/Physical Description"] = x["properties"][
+            "ucldc_schema:physdesc"]
+    elif all_headers == "y":
+        data2["Format/Physical Description"] = ""
 
 
 def get_description(data2, x, all_headers):
     descnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:description'],
-            list) and len(x['properties']['ucldc_schema:description']) > 0:
-        while descnumb < len(x['properties']['ucldc_schema:description']):
+            x["properties"]["ucldc_schema:description"],
+            list) and len(x["properties"]["ucldc_schema:description"]) > 0:
+        while descnumb < len(x["properties"]["ucldc_schema:description"]):
             numb = descnumb + 1
             try:
                 name = "Description %d Note" % numb
-                if x['properties']['ucldc_schema:description'][descnumb][
-                        'item'] is not None and x['properties'][
-                            'ucldc_schema:description'][descnumb]['item'] != '':
-                    data2[name] = x['properties']['ucldc_schema:description'][
-                        descnumb]['item']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                if x["properties"]["ucldc_schema:description"][descnumb][
+                        "item"] is not None and x["properties"][
+                            "ucldc_schema:description"][descnumb]["item"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:description"][
+                        descnumb]["item"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
                 name = "Description %d Type" % numb
-                if x['properties']['ucldc_schema:description'][descnumb][
-                        'type'] is not None and x['properties'][
-                            'ucldc_schema:description'][descnumb]['type'] != '':
-                    data2[name] = x['properties']['ucldc_schema:description'][
-                        descnumb]['type']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                if x["properties"]["ucldc_schema:description"][descnumb][
+                        "type"] is not None and x["properties"][
+                            "ucldc_schema:description"][descnumb]["type"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:description"][
+                        descnumb]["type"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             descnumb += 1
-    elif all_headers == 'y':
-        data2['Description 1 Note'] = ''
-        data2['Description 1 Type'] = ''
+    elif all_headers == "y":
+        data2["Description 1 Note"] = ""
+        data2["Description 1 Type"] = ""
 
 
 def get_extent(data2, x, all_headers):
-    if x['properties']['ucldc_schema:extent'] is not None and x['properties'][
-            'ucldc_schema:extent'] != '':
-        data2['Extent'] = x['properties']['ucldc_schema:extent']
-    elif all_headers == 'y':
-        data2['Extent'] = ''
+    if x["properties"]["ucldc_schema:extent"] is not None and x["properties"][
+            "ucldc_schema:extent"] != "":
+        data2["Extent"] = x["properties"]["ucldc_schema:extent"]
+    elif all_headers == "y":
+        data2["Extent"] = ""
 
 
 def get_language(data2, x, all_headers):
     langnumb = 0
-    if isinstance(x['properties']['ucldc_schema:language'],
-                  list) and len(x['properties']['ucldc_schema:language']) > 0:
-        while langnumb < len(x['properties']['ucldc_schema:language']):
+    if isinstance(x["properties"]["ucldc_schema:language"],
+                  list) and len(x["properties"]["ucldc_schema:language"]) > 0:
+        while langnumb < len(x["properties"]["ucldc_schema:language"]):
             numb = langnumb + 1
             try:
                 name = "Language %d" % numb
-                if x['properties']['ucldc_schema:language'][langnumb][
-                        'language'] is not None and x['properties'][
-                            'ucldc_schema:language'][langnumb][
-                                'language'] != '':
-                    data2[name] = x['properties']['ucldc_schema:language'][
-                        langnumb]['language']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                if x["properties"]["ucldc_schema:language"][langnumb][
+                        "language"] is not None and x["properties"][
+                            "ucldc_schema:language"][langnumb][
+                                "language"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:language"][
+                        langnumb]["language"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
                 name = "Language %d Code" % numb
-                if x['properties']['ucldc_schema:language'][langnumb][
-                        'languagecode'] is not None and x['properties'][
-                            'ucldc_schema:language'][langnumb][
-                                'languagecode'] != '':
-                    data2[name] = x['properties']['ucldc_schema:language'][
-                        langnumb]['languagecode']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                if x["properties"]["ucldc_schema:language"][langnumb][
+                        "languagecode"] is not None and x["properties"][
+                            "ucldc_schema:language"][langnumb][
+                                "languagecode"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:language"][
+                        langnumb]["languagecode"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             langnumb += 1
-    elif all_headers == 'y':
-        data2['Language 1'] = ''
-        data2['Language 1 Code'] = ''
+    elif all_headers == "y":
+        data2["Language 1"] = ""
+        data2["Language 1 Code"] = ""
 
 
 def get_temporal_coverage(data2, x, all_headers):
     tempnumb = 0
-    if isinstance(x['properties']['ucldc_schema:temporalcoverage'],
+    if isinstance(x["properties"]["ucldc_schema:temporalcoverage"],
                   list) and len(
-                      x['properties']['ucldc_schema:temporalcoverage']) > 0:
-        while tempnumb < len(x['properties']['ucldc_schema:temporalcoverage']):
+                      x["properties"]["ucldc_schema:temporalcoverage"]) > 0:
+        while tempnumb < len(x["properties"]["ucldc_schema:temporalcoverage"]):
             numb = tempnumb + 1
-            name = 'Temporal Coverage %d' % numb
-            data2[name] = x['properties']['ucldc_schema:temporalcoverage'][
+            name = "Temporal Coverage %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:temporalcoverage"][
                 tempnumb]
             tempnumb += 1
-    elif all_headers == 'y':
-        data2['Temporal Coverage 1'] = ''
+    elif all_headers == "y":
+        data2["Temporal Coverage 1"] = ""
 
 
 def get_transcription(data2, x, all_headers):
-    if x['properties']['ucldc_schema:transcription'] is not None and x[
-            'properties']['ucldc_schema:transcription'] != '':
-        data2['Transcription'] = x['properties']['ucldc_schema:transcription']
-    elif all_headers == 'y':
-        data2['Transcription'] = ''
+    if x["properties"]["ucldc_schema:transcription"] is not None and x[
+            "properties"]["ucldc_schema:transcription"] != "":
+        data2["Transcription"] = x["properties"]["ucldc_schema:transcription"]
+    elif all_headers == "y":
+        data2["Transcription"] = ""
 
 
 def get_access_restrictions(data2, x, all_headers):
-    if x['properties']['ucldc_schema:accessrestrict'] is not None and x[
-            'properties']['ucldc_schema:accessrestrict'] != '':
-        data2['Access Restrictions'] = x['properties'][
-            'ucldc_schema:accessrestrict']
-    elif all_headers == 'y':
-        data2['Access Restrictions'] = ''
+    if x["properties"]["ucldc_schema:accessrestrict"] is not None and x[
+            "properties"]["ucldc_schema:accessrestrict"] != "":
+        data2["Access Restrictions"] = x["properties"][
+            "ucldc_schema:accessrestrict"]
+    elif all_headers == "y":
+        data2["Access Restrictions"] = ""
 
 
 def get_rights_statement(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightsstatement'] is not None and x[
-            'properties']['ucldc_schema:rightsstatement'] != '':
-        data2['Copyright Statement'] = x['properties'][
-            'ucldc_schema:rightsstatement']
-    elif all_headers == 'y':
-        data2['Copyright Statement'] = ''
+    if x["properties"]["ucldc_schema:rightsstatement"] is not None and x[
+            "properties"]["ucldc_schema:rightsstatement"] != "":
+        data2["Copyright Statement"] = x["properties"][
+            "ucldc_schema:rightsstatement"]
+    elif all_headers == "y":
+        data2["Copyright Statement"] = ""
 
 
 def get_rights_status(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightsstatus'] is not None and x[
-            'properties']['ucldc_schema:rightsstatus'] != '':
-        data2['Copyright Status'] = x['properties'][
-            'ucldc_schema:rightsstatus']
-    elif all_headers == 'y':
-        data2['Copyright Status'] = ''
+    if x["properties"]["ucldc_schema:rightsstatus"] is not None and x[
+            "properties"]["ucldc_schema:rightsstatus"] != "":
+        data2["Copyright Status"] = x["properties"][
+            "ucldc_schema:rightsstatus"]
+    elif all_headers == "y":
+        data2["Copyright Status"] = ""
 
 
 def get_copyright_holder(data2, x, all_headers):
     rightsnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:rightsholder'],
-            list) and len(x['properties']['ucldc_schema:rightsholder']) > 0:
-        while rightsnumb < len(x['properties']['ucldc_schema:rightsholder']):
+            x["properties"]["ucldc_schema:rightsholder"],
+            list) and len(x["properties"]["ucldc_schema:rightsholder"]) > 0:
+        while rightsnumb < len(x["properties"]["ucldc_schema:rightsholder"]):
             numb = rightsnumb + 1
             try:
-                name = 'Copyright Holder %d Name' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'name'] is not None and x['properties'][
-                            'ucldc_schema:rightsholder'][rightsnumb][
-                                'name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
-                        rightsnumb]['name']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Copyright Holder %d Name" % numb
+                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
+                        "name"] is not None and x["properties"][
+                            "ucldc_schema:rightsholder"][rightsnumb][
+                                "name"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["name"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Copyright Holder %d Name Type' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'nametype'] is not None and x['properties'][
-                            'ucldc_schema:rightsholder'][rightsnumb][
-                                'nametype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
-                        rightsnumb]['nametype']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Copyright Holder %d Name Type" % numb
+                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
+                        "nametype"] is not None and x["properties"][
+                            "ucldc_schema:rightsholder"][rightsnumb][
+                                "nametype"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["nametype"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Copyright Holder %d Source' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:rightsholder'][rightsnumb][
-                                'source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
-                        rightsnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Copyright Holder %d Source" % numb
+                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:rightsholder"][rightsnumb][
+                                "source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Copyright Holder %d Authority ID' % numb
-                if x['properties']['ucldc_schema:rightsholder'][rightsnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:rightsholder'][rightsnumb][
-                                'authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:rightsholder'][
-                        rightsnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Copyright Holder %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:rightsholder"][rightsnumb][
+                                "authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             rightsnumb += 1
-    elif all_headers == 'y':
-        data2['Copyright Holder 1 Name'] = ''
-        data2['Copyright Holder 1 Name Type'] = ''
-        data2['Copyright Holder 1 Source'] = ''
-        data2['Copyright Holder 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Copyright Holder 1 Name"] = ""
+        data2["Copyright Holder 1 Name Type"] = ""
+        data2["Copyright Holder 1 Source"] = ""
+        data2["Copyright Holder 1 Authority ID"] = ""
 
 
 def get_copyright_info(data2, x, all_headers):
-    if x['properties']['ucldc_schema:rightscontact'] is not None and x[
-            'properties']['ucldc_schema:rightscontact'] != '':
-        data2['Copyright Contact'] = x['properties'][
-            'ucldc_schema:rightscontact']
-    elif all_headers == 'y':
-        data2['Copyright Contact'] = ''
+    if x["properties"]["ucldc_schema:rightscontact"] is not None and x[
+            "properties"]["ucldc_schema:rightscontact"] != "":
+        data2["Copyright Contact"] = x["properties"][
+            "ucldc_schema:rightscontact"]
+    elif all_headers == "y":
+        data2["Copyright Contact"] = ""
 
-    if x['properties']['ucldc_schema:rightsnotice'] is not None and x[
-            'properties']['ucldc_schema:rightsnotice'] != '':
-        data2['Copyright Notice'] = x['properties'][
-            'ucldc_schema:rightsnotice']
-    elif all_headers == 'y':
-        data2['Copyright Notice'] = ''
+    if x["properties"]["ucldc_schema:rightsnotice"] is not None and x[
+            "properties"]["ucldc_schema:rightsnotice"] != "":
+        data2["Copyright Notice"] = x["properties"][
+            "ucldc_schema:rightsnotice"]
+    elif all_headers == "y":
+        data2["Copyright Notice"] = ""
 
-    if x['properties'][
-            'ucldc_schema:rightsdeterminationdate'] is not None and x[
-                'properties']['ucldc_schema:rightsdeterminationdate'] != '':
-        data2['Copyright Determination Date'] = x['properties'][
-            'ucldc_schema:rightsdeterminationdate']
-    elif all_headers == 'y':
-        data2['Copyright Determination Date'] = ''
+    if x["properties"][
+            "ucldc_schema:rightsdeterminationdate"] is not None and x[
+                "properties"]["ucldc_schema:rightsdeterminationdate"] != "":
+        data2["Copyright Determination Date"] = x["properties"][
+            "ucldc_schema:rightsdeterminationdate"]
+    elif all_headers == "y":
+        data2["Copyright Determination Date"] = ""
 
-    if x['properties']['ucldc_schema:rightsstartdate'] is not None and x[
-            'properties']['ucldc_schema:rightsstartdate'] != '':
-        data2['Copyright Start Date'] = x['properties'][
-            'ucldc_schema:rightsstartdate']
-    elif all_headers == 'y':
-        data2['Copyright Start Date'] = ''
+    if x["properties"]["ucldc_schema:rightsstartdate"] is not None and x[
+            "properties"]["ucldc_schema:rightsstartdate"] != "":
+        data2["Copyright Start Date"] = x["properties"][
+            "ucldc_schema:rightsstartdate"]
+    elif all_headers == "y":
+        data2["Copyright Start Date"] = ""
 
-    if x['properties']['ucldc_schema:rightsenddate'] is not None and x[
-            'properties']['ucldc_schema:rightsenddate'] != '':
-        data2['Copyright End Date'] = x['properties'][
-            'ucldc_schema:rightsenddate']
-    elif all_headers == 'y':
-        data2['Copyright End Date'] = ''
+    if x["properties"]["ucldc_schema:rightsenddate"] is not None and x[
+            "properties"]["ucldc_schema:rightsenddate"] != "":
+        data2["Copyright End Date"] = x["properties"][
+            "ucldc_schema:rightsenddate"]
+    elif all_headers == "y":
+        data2["Copyright End Date"] = ""
 
-    if x['properties']['ucldc_schema:rightsjurisdiction'] is not None and x[
-            'properties']['ucldc_schema:rightsjurisdiction'] != '':
-        data2['Copyright Jurisdiction'] = x['properties'][
-            'ucldc_schema:rightsjurisdiction']
-    elif all_headers == 'y':
-        data2['Copyright Jurisdiction'] = ''
+    if x["properties"]["ucldc_schema:rightsjurisdiction"] is not None and x[
+            "properties"]["ucldc_schema:rightsjurisdiction"] != "":
+        data2["Copyright Jurisdiction"] = x["properties"][
+            "ucldc_schema:rightsjurisdiction"]
+    elif all_headers == "y":
+        data2["Copyright Jurisdiction"] = ""
 
-    if x['properties']['ucldc_schema:rightsnote'] is not None and x[
-            'properties']['ucldc_schema:rightsnote'] != '':
-        data2['Copyright Note'] = x['properties']['ucldc_schema:rightsnote']
-    elif all_headers == 'y':
-        data2['Copyright Note'] = ''
+    if x["properties"]["ucldc_schema:rightsnote"] is not None and x[
+            "properties"]["ucldc_schema:rightsnote"] != "":
+        data2["Copyright Note"] = x["properties"]["ucldc_schema:rightsnote"]
+    elif all_headers == "y":
+        data2["Copyright Note"] = ""
 
 
 def get_collection(data2, x, all_headers):
     collnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:collection'],
-            list) and len(x['properties']['ucldc_schema:collection']) > 0:
-        while collnumb < len(x['properties']['ucldc_schema:collection']):
+            x["properties"]["ucldc_schema:collection"],
+            list) and len(x["properties"]["ucldc_schema:collection"]) > 0:
+        while collnumb < len(x["properties"]["ucldc_schema:collection"]):
             numb = collnumb + 1
-            name = 'Collection %d' % numb
-            data2[name] = x['properties']['ucldc_schema:collection'][collnumb]
+            name = "Collection %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:collection"][collnumb]
             collnumb += 1
-    elif all_headers == 'y':
-        data2['Collection 1'] = ''
+    elif all_headers == "y":
+        data2["Collection 1"] = ""
 
 
 def get_related_resource(data2, x, all_headers):
     relnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:relatedresource'],
-            list) and len(x['properties']['ucldc_schema:relatedresource']) > 0:
-        while relnumb < len(x['properties']['ucldc_schema:relatedresource']):
+            x["properties"]["ucldc_schema:relatedresource"],
+            list) and len(x["properties"]["ucldc_schema:relatedresource"]) > 0:
+        while relnumb < len(x["properties"]["ucldc_schema:relatedresource"]):
             numb = relnumb + 1
-            name = 'Related Resource %d' % numb
-            data2[name] = x['properties']['ucldc_schema:relatedresource'][
+            name = "Related Resource %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:relatedresource"][
                 relnumb]
             relnumb += 1
-    elif all_headers == 'y':
-        data2['Related Resource 1'] = ''
+    elif all_headers == "y":
+        data2["Related Resource 1"] = ""
 
 
 def get_source(data2, x, all_headers):
-    if x['properties']['ucldc_schema:source'] is not None and x['properties'][
-            'ucldc_schema:source'] != '':
-        data2['Source'] = x['properties']['ucldc_schema:source']
-    elif all_headers == 'y':
-        data2['Source'] = ''
+    if x["properties"]["ucldc_schema:source"] is not None and x["properties"][
+            "ucldc_schema:source"] != "":
+        data2["Source"] = x["properties"]["ucldc_schema:source"]
+    elif all_headers == "y":
+        data2["Source"] = ""
 
 
 def get_subject_name(data2, x, all_headers):
     subnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:subjectname'],
-            list) and len(x['properties']['ucldc_schema:subjectname']) > 0:
-        while subnumb < len(x['properties']['ucldc_schema:subjectname']):
+            x["properties"]["ucldc_schema:subjectname"],
+            list) and len(x["properties"]["ucldc_schema:subjectname"]) > 0:
+        while subnumb < len(x["properties"]["ucldc_schema:subjectname"]):
             numb = subnumb + 1
             try:
-                name = 'Subject (Name) %d Name' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'name'] is not None and x['properties'][
-                            'ucldc_schema:subjectname'][subnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][
-                        subnumb]['name']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Name) %d Name" % numb
+                if x["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "name"] is not None and x["properties"][
+                            "ucldc_schema:subjectname"][subnumb]["name"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
+                        subnumb]["name"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Name) %d Name Type' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'name_type'] is not None and x['properties'][
-                            'ucldc_schema:subjectname'][subnumb][
-                                'name_type'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][
-                        subnumb]['name_type']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Name) %d Name Type" % numb
+                if x["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "name_type"] is not None and x["properties"][
+                            "ucldc_schema:subjectname"][subnumb][
+                                "name_type"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
+                        subnumb]["name_type"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Name) %d Role' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'role'] is not None and x['properties'][
-                            'ucldc_schema:subjectname'][subnumb]['role'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][
-                        subnumb]['role']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Name) %d Role" % numb
+                if x["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "role"] is not None and x["properties"][
+                            "ucldc_schema:subjectname"][subnumb]["role"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
+                        subnumb]["role"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Name) %d Source' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:subjectname'][subnumb][
-                                'source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][
-                        subnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Name) %d Source" % numb
+                if x["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:subjectname"][subnumb][
+                                "source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
+                        subnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Name) %d Authority ID' % numb
-                if x['properties']['ucldc_schema:subjectname'][subnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:subjectname'][subnumb][
-                                'authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjectname'][
-                        subnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Name) %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:subjectname"][subnumb][
+                                "authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
+                        subnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             subnumb += 1
-    elif all_headers == 'y':
-        data2['Subject (Name) 1 Name'] = ''
-        data2['Subject (Name) 1 Name Type'] = ''
-        data2['Subject (Name) 1 Role'] = ''
-        data2['Subject (Name) 1 Source'] = ''
-        data2['Subject (Name) 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Subject (Name) 1 Name"] = ""
+        data2["Subject (Name) 1 Name Type"] = ""
+        data2["Subject (Name) 1 Role"] = ""
+        data2["Subject (Name) 1 Source"] = ""
+        data2["Subject (Name) 1 Authority ID"] = ""
 
 
 def get_place(data2, x, all_headers):
     plcnumb = 0
-    if isinstance(x['properties']['ucldc_schema:place'],
-                  list) and len(x['properties']['ucldc_schema:place']) > 0:
-        while plcnumb < len(x['properties']['ucldc_schema:place']):
+    if isinstance(x["properties"]["ucldc_schema:place"],
+                  list) and len(x["properties"]["ucldc_schema:place"]) > 0:
+        while plcnumb < len(x["properties"]["ucldc_schema:place"]):
             numb = plcnumb + 1
             try:
-                name = 'Place %d Name' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb][
-                        'name'] is not None and x['properties'][
-                            'ucldc_schema:place'][plcnumb]['name'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][
-                        plcnumb]['name']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Place %d Name" % numb
+                if x["properties"]["ucldc_schema:place"][plcnumb][
+                        "name"] is not None and x["properties"][
+                            "ucldc_schema:place"][plcnumb]["name"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:place"][
+                        plcnumb]["name"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Place %d Coordinates' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb][
-                        'coordinates'] is not None and x['properties'][
-                            'ucldc_schema:place'][plcnumb]['coordinates'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][
-                        plcnumb]['coordinates']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Place %d Coordinates" % numb
+                if x["properties"]["ucldc_schema:place"][plcnumb][
+                        "coordinates"] is not None and x["properties"][
+                            "ucldc_schema:place"][plcnumb]["coordinates"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:place"][
+                        plcnumb]["coordinates"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Place %d Source' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:place'][plcnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][
-                        plcnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Place %d Source" % numb
+                if x["properties"]["ucldc_schema:place"][plcnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:place"][plcnumb]["source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:place"][
+                        plcnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Place %d Authority ID' % numb
-                if x['properties']['ucldc_schema:place'][plcnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:place'][plcnumb]['authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:place'][
-                        plcnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Place %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:place"][plcnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:place"][plcnumb]["authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:place"][
+                        plcnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             plcnumb += 1
-    elif all_headers == 'y':
-        data2['Place 1 Name'] = ''
-        data2['Place 1 Coordinates'] = ''
-        data2['Place 1 Source'] = ''
-        data2['Place 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Place 1 Name"] = ""
+        data2["Place 1 Coordinates"] = ""
+        data2["Place 1 Source"] = ""
+        data2["Place 1 Authority ID"] = ""
 
 
 def get_subject_topic(data2, x, all_headers):
     topnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:subjecttopic'],
-            list) and len(x['properties']['ucldc_schema:subjecttopic']) > 0:
-        while topnumb < len(x['properties']['ucldc_schema:subjecttopic']):
+            x["properties"]["ucldc_schema:subjecttopic"],
+            list) and len(x["properties"]["ucldc_schema:subjecttopic"]) > 0:
+        while topnumb < len(x["properties"]["ucldc_schema:subjecttopic"]):
             numb = topnumb + 1
             try:
-                name = 'Subject (Topic) %d Heading' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'heading'] is not None and x['properties'][
-                            'ucldc_schema:subjecttopic'][topnumb][
-                                'heading'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
-                        topnumb]['heading']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Topic) %d Heading" % numb
+                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "heading"] is not None and x["properties"][
+                            "ucldc_schema:subjecttopic"][topnumb][
+                                "heading"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
+                        topnumb]["heading"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Topic) %d Heading Type' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'headingtype'] is not None and x['properties'][
-                            'ucldc_schema:subjecttopic'][topnumb][
-                                'headingtype'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
-                        topnumb]['headingtype']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Topic) %d Heading Type" % numb
+                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "headingtype"] is not None and x["properties"][
+                            "ucldc_schema:subjecttopic"][topnumb][
+                                "headingtype"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
+                        topnumb]["headingtype"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Topic) %d Source' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:subjecttopic'][topnumb][
-                                'source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
-                        topnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Topic) %d Source" % numb
+                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:subjecttopic"][topnumb][
+                                "source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
+                        topnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Subject (Topic) %d Authority ID' % numb
-                if x['properties']['ucldc_schema:subjecttopic'][topnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:subjecttopic'][topnumb][
-                                'authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:subjecttopic'][
-                        topnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Subject (Topic) %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:subjecttopic"][topnumb][
+                                "authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
+                        topnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             topnumb += 1
-    elif all_headers == 'y':
-        data2['Subject (Topic) 1 Heading'] = ''
-        data2['Subject (Topic) 1 Heading Type'] = ''
-        data2['Subject (Topic) 1 Source'] = ''
-        data2['Subject (Topic) 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Subject (Topic) 1 Heading"] = ""
+        data2["Subject (Topic) 1 Heading Type"] = ""
+        data2["Subject (Topic) 1 Source"] = ""
+        data2["Subject (Topic) 1 Authority ID"] = ""
 
 
 def get_form_genre(data2, x, all_headers):
     formnumb = 0
-    if isinstance(x['properties']['ucldc_schema:formgenre'],
-                  list) and len(x['properties']['ucldc_schema:formgenre']) > 0:
-        while formnumb < len(x['properties']['ucldc_schema:formgenre']):
+    if isinstance(x["properties"]["ucldc_schema:formgenre"],
+                  list) and len(x["properties"]["ucldc_schema:formgenre"]) > 0:
+        while formnumb < len(x["properties"]["ucldc_schema:formgenre"]):
             numb = formnumb + 1
             try:
-                name = 'Form/Genre %d Heading' % numb
-                if x['properties']['ucldc_schema:formgenre'][formnumb][
-                        'heading'] is not None and x['properties'][
-                            'ucldc_schema:formgenre'][formnumb][
-                                'heading'] != '':
-                    data2[name] = x['properties']['ucldc_schema:formgenre'][
-                        formnumb]['heading']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Form/Genre %d Heading" % numb
+                if x["properties"]["ucldc_schema:formgenre"][formnumb][
+                        "heading"] is not None and x["properties"][
+                            "ucldc_schema:formgenre"][formnumb][
+                                "heading"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:formgenre"][
+                        formnumb]["heading"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Form/Genre %d Source' % numb
-                if x['properties']['ucldc_schema:formgenre'][formnumb][
-                        'source'] is not None and x['properties'][
-                            'ucldc_schema:formgenre'][formnumb]['source'] != '':
-                    data2[name] = x['properties']['ucldc_schema:formgenre'][
-                        formnumb]['source']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Form/Genre %d Source" % numb
+                if x["properties"]["ucldc_schema:formgenre"][formnumb][
+                        "source"] is not None and x["properties"][
+                            "ucldc_schema:formgenre"][formnumb]["source"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:formgenre"][
+                        formnumb]["source"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             try:
-                name = 'Form/Genre %d Authority ID' % numb
-                if x['properties']['ucldc_schema:formgenre'][formnumb][
-                        'authorityid'] is not None and x['properties'][
-                            'ucldc_schema:formgenre'][formnumb][
-                                'authorityid'] != '':
-                    data2[name] = x['properties']['ucldc_schema:formgenre'][
-                        formnumb]['authorityid']
-                elif all_headers == 'y':
-                    data2[name] = ''
+                name = "Form/Genre %d Authority ID" % numb
+                if x["properties"]["ucldc_schema:formgenre"][formnumb][
+                        "authorityid"] is not None and x["properties"][
+                            "ucldc_schema:formgenre"][formnumb][
+                                "authorityid"] != "":
+                    data2[name] = x["properties"]["ucldc_schema:formgenre"][
+                        formnumb]["authorityid"]
+                elif all_headers == "y":
+                    data2[name] = ""
             except:
                 pass
             formnumb += 1
-    elif all_headers == 'y':
-        data2['Form/Genre 1 Heading'] = ''
-        data2['Form/Genre 1 Source'] = ''
-        data2['Form/Genre 1 Authority ID'] = ''
+    elif all_headers == "y":
+        data2["Form/Genre 1 Heading"] = ""
+        data2["Form/Genre 1 Source"] = ""
+        data2["Form/Genre 1 Authority ID"] = ""
 
 
 def get_provenance(data2, x, all_headers):
     provnumb = 0
     if isinstance(
-            x['properties']['ucldc_schema:provenance'],
-            list) and len(x['properties']['ucldc_schema:provenance']) > 0:
-        while provnumb < len(x['properties']['ucldc_schema:provenance']):
+            x["properties"]["ucldc_schema:provenance"],
+            list) and len(x["properties"]["ucldc_schema:provenance"]) > 0:
+        while provnumb < len(x["properties"]["ucldc_schema:provenance"]):
             numb = provnumb + 1
-            name = 'Provenance %d' % numb
-            data2[name] = x['properties']['ucldc_schema:provenance'][provnumb]
+            name = "Provenance %d" % numb
+            data2[name] = x["properties"]["ucldc_schema:provenance"][provnumb]
             provnumb += 1
-    elif all_headers == 'y':
-        data2['Provenance 1'] = ''
+    elif all_headers == "y":
+        data2["Provenance 1"] = ""
 
 
 def get_physical_location(data2, x, all_headers):
-    if x['properties']['ucldc_schema:physlocation'] is not None and x[
-            'properties']['ucldc_schema:physlocation'] != '':
-        data2['Physical Location'] = x['properties'][
-            'ucldc_schema:physlocation']
-    elif all_headers == 'y':
-        data2['Physical Location'] = ''
+    if x["properties"]["ucldc_schema:physlocation"] is not None and x[
+            "properties"]["ucldc_schema:physlocation"] != "":
+        data2["Physical Location"] = x["properties"][
+            "ucldc_schema:physlocation"]
+    elif all_headers == "y":
+        data2["Physical Location"] = ""
 
 
 def object_level(filepath, all_headers):
@@ -992,7 +992,7 @@ def object_level(filepath, all_headers):
         data.append(data2)
 
     fieldnames = [
-        'File path', 'Title', 'Type'
+        "File path", "Title", "Type"
     ]  #ensures that File path, Title and Type are the first three rows
     for data2 in data:
         for key, value in data2.items():
@@ -1000,13 +1000,13 @@ def object_level(filepath, all_headers):
                 fieldnames.append(key)
 
     return {
-        'fieldnames':
+        "fieldnames":
         fieldnames,
-        'data':
+        "data":
         data,
-        'filename':
+        "filename":
         "nuxeo_object_%s.tsv" %
-        nx.get_metadata(path=filepath)['properties']['dc:title']
+        nx.get_metadata(path=filepath)["properties"]["dc:title"]
     }
 
 
@@ -1014,7 +1014,7 @@ def item_level(filepath, all_headers):
     nx = utils.Nuxeo()
     data = []
     for n in nx.children(filepath):
-        for x in nx.children(n['path']):
+        for x in nx.children(n["path"]):
             data2 = {}
             get_title(data2, x)
             get_filepath(data2, x)
@@ -1050,7 +1050,7 @@ def item_level(filepath, all_headers):
             data.append(data2)
 
     fieldnames = [
-        'File path', 'Title', 'Type'
+        "File path", "Title", "Type"
     ]  #ensures that File path, Title and Type are the first three rows
     for data2 in data:
         for key, value in data2.items():
@@ -1058,13 +1058,13 @@ def item_level(filepath, all_headers):
                 fieldnames.append(key)
 
     return {
-        'fieldnames':
+        "fieldnames":
         fieldnames,
-        'data':
+        "data":
         data,
-        'filename':
+        "filename":
         "nuxeo_item_%s.tsv" %
-        nx.get_metadata(path=filepath)['properties']['dc:title']
+        nx.get_metadata(path=filepath)["properties"]["dc:title"]
     }
 
 
@@ -1079,24 +1079,24 @@ def google_object(filepath, all_headers, url):
     obj = object_level(filepath, all_headers)
     nx = utils.Nuxeo()
     scope = [
-        'https://spreadsheets.google.com/feeds',
-        'https://www.googleapis.com/auth/drive'
+        "https://spreadsheets.google.com/feeds",
+        "https://www.googleapis.com/auth/drive"
     ]
     creds = ServiceAccountCredentials.from_json_keyfile_name(
-        'client_secret.json', scope)
+        "client_secret.json", scope)
     client = gspread.authorize(creds)
     with open("temp.csv", "wb") as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=obj['fieldnames'])
+        writer = csv.DictWriter(csvfile, fieldnames=obj["fieldnames"])
         writer.writeheader()
-        for row in obj['data']:
+        for row in obj["data"]:
             writer.writerow(row)
     with open("temp.csv", encoding="utf8") as f:
-        s = f.read() + '\n'
+        s = f.read() + "\n"
     sheet_id = client.open_by_url(url).id
     client.import_csv(sheet_id, s)
     client.open_by_key(sheet_id).sheet1.update_title(
         "nuxeo_object_%s" %
-        nx.get_metadata(path=filepath)['properties']['dc:title'])
+        nx.get_metadata(path=filepath)["properties"]["dc:title"])
     os.remove("temp.csv")
 
 
@@ -1106,27 +1106,27 @@ def google_item(filepath, all_headers, url):
     item = item_level(filepath, all_headers)
     nx = utils.Nuxeo()
     scope = [
-        'https://spreadsheets.google.com/feeds',
-        'https://www.googleapis.com/auth/drive'
+        "https://spreadsheets.google.com/feeds",
+        "https://www.googleapis.com/auth/drive"
     ]
     creds = ServiceAccountCredentials.from_json_keyfile_name(
-        'client_secret.json', scope)
+        "client_secret.json", scope)
     client = gspread.authorize(creds)
     with open("temp.csv", "wb") as csvfile:  #creates temporary csv file
-        writer = csv.DictWriter(csvfile, fieldnames=item['fieldnames'])
+        writer = csv.DictWriter(csvfile, fieldnames=item["fieldnames"])
         writer.writeheader()
-        for row in item['data']:
+        for row in item["data"]:
             writer.writerow(row)
     with open("temp.csv",
               encoding="utf8") as f:  #opens and reads temporary csv file
-        s = f.read() + '\n'
+        s = f.read() + "\n"
     sheet_id = client.open_by_url(url).id
     client.import_csv(sheet_id, s)  #writes csv file to google sheet
     client.open_by_key(sheet_id).sheet1.update_title(
         "nuxeo_item_%s" %
-        nx.get_metadata(path=filepath)['properties']['dc:title'])
+        nx.get_metadata(path=filepath)["properties"]["dc:title"])
     os.remove("temp.csv")  #removes temporary csv
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -32,6 +32,11 @@ try:
 except:
     all_headers = input('All Headers? (Y/N): ')
 
+filepath = filepath.strip()
+choice = choice.lower().strip()
+url = url.strip()
+all_headers = choice.lower().strip()
+
 
 def get_title(data2, x):
     """gets title
@@ -52,7 +57,7 @@ def get_type(data2, x, all_headers):
     if x['properties']['ucldc_schema:type'] != None and x['properties'][
             'ucldc_schema:type'] != '':
         data2['Type'] = x['properties']['ucldc_schema:type']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Type'] = ''
 
 
@@ -66,7 +71,7 @@ def get_alt_title(data2, x, all_headers):
             data2[name] = x['properties']['ucldc_schema:alternativetitle'][
                 altnumb]
             altnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Alternative Title 1'] = ''
 
 
@@ -74,7 +79,7 @@ def get_identifier(data2, x, all_headers):
     if x['properties']['ucldc_schema:identifier'] != None and x['properties'][
             'ucldc_schema:identifier'] != '':
         data2['Identifier'] = x['properties']['ucldc_schema:identifier']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Identifier'] = ''
 
 
@@ -88,7 +93,7 @@ def get_local_identifier(data2, x, all_headers):
             data2[name] = x['properties']['ucldc_schema:localidentifier'][
                 locnumb]
             locnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Local Identifier 1'] = ''
 
 
@@ -101,7 +106,7 @@ def get_campus_unit(data2, x, all_headers):
             name = 'Campus/Unit %d' % numb
             data2[name] = x['properties']['ucldc_schema:campusunit'][campnumb]
             campnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Campus/Unit 1'] = ''
 
 
@@ -118,7 +123,7 @@ def get_date(data2, x, all_headers):
                             'ucldc_schema:date'][datenumb]['date'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['date']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -129,7 +134,7 @@ def get_date(data2, x, all_headers):
                             'ucldc_schema:date'][datenumb]['datetype'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['datetype']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -141,7 +146,7 @@ def get_date(data2, x, all_headers):
                                 'inclusivestart'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['inclusivestart']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -153,7 +158,7 @@ def get_date(data2, x, all_headers):
                                 'inclusiveend'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['inclusiveend']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -164,12 +169,12 @@ def get_date(data2, x, all_headers):
                             'ucldc_schema:date'][datenumb]['single'] != '':
                     data2[name] = x['properties']['ucldc_schema:date'][
                         datenumb]['single']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             datenumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Date 1'] = ''
         data2['Date 1 Type'] = ''
         data2['Date 1 Inclusive Start'] = ''
@@ -186,7 +191,7 @@ def get_publication(data2, x, all_headers):
             name = 'Publication/Origination Info %d' % numb
             data2[name] = x['properties']['ucldc_schema:publisher'][pubnumb]
             pubnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Publication/Origination Info 1'] = ''
 
 
@@ -203,7 +208,7 @@ def get_creator(data2, x, all_headers):
                             'ucldc_schema:creator'][creatnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['name']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -215,7 +220,7 @@ def get_creator(data2, x, all_headers):
                                 'nametype'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['nametype']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -226,7 +231,7 @@ def get_creator(data2, x, all_headers):
                             'ucldc_schema:creator'][creatnumb]['role'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['role']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -237,7 +242,7 @@ def get_creator(data2, x, all_headers):
                             'ucldc_schema:creator'][creatnumb]['source'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -249,12 +254,12 @@ def get_creator(data2, x, all_headers):
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:creator'][
                         creatnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             creatnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Creator 1 Name'] = ''
         data2['Creator 1 Name Type'] = ''
         data2['Creator 1 Role'] = ''
@@ -275,7 +280,7 @@ def get_contributor(data2, x, all_headers):
                             'ucldc_schema:contributor'][contnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['name']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -287,7 +292,7 @@ def get_contributor(data2, x, all_headers):
                                 'nametype'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['nametype']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -298,7 +303,7 @@ def get_contributor(data2, x, all_headers):
                             'ucldc_schema:contributor'][contnumb]['role'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['role']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -310,7 +315,7 @@ def get_contributor(data2, x, all_headers):
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -322,12 +327,12 @@ def get_contributor(data2, x, all_headers):
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:contributor'][
                         contnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             contnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Contributor 1 Name'] = ''
         data2['Contributor 1 Name Type'] = ''
         data2['Contributor 1 Role'] = ''
@@ -340,7 +345,7 @@ def get_format(data2, x, all_headers):
             'ucldc_schema:physdesc'] != '':
         data2['Format/Physical Description'] = x['properties'][
             'ucldc_schema:physdesc']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Format/Physical Description'] = ''
 
 
@@ -357,7 +362,7 @@ def get_description(data2, x, all_headers):
                             'ucldc_schema:description'][descnumb]['item'] != '':
                     data2[name] = x['properties']['ucldc_schema:description'][
                         descnumb]['item']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -368,12 +373,12 @@ def get_description(data2, x, all_headers):
                             'ucldc_schema:description'][descnumb]['type'] != '':
                     data2[name] = x['properties']['ucldc_schema:description'][
                         descnumb]['type']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             descnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Description 1 Note'] = ''
         data2['Description 1 Type'] = ''
 
@@ -382,7 +387,7 @@ def get_extent(data2, x, all_headers):
     if x['properties']['ucldc_schema:extent'] != None and x['properties'][
             'ucldc_schema:extent'] != '':
         data2['Extent'] = x['properties']['ucldc_schema:extent']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Extent'] = ''
 
 
@@ -400,7 +405,7 @@ def get_language(data2, x, all_headers):
                                 'language'] != '':
                     data2[name] = x['properties']['ucldc_schema:language'][
                         langnumb]['language']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -412,12 +417,12 @@ def get_language(data2, x, all_headers):
                                 'languagecode'] != '':
                     data2[name] = x['properties']['ucldc_schema:language'][
                         langnumb]['languagecode']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             langnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Language 1'] = ''
         data2['Language 1 Code'] = ''
 
@@ -432,7 +437,7 @@ def get_temporal_coverage(data2, x, all_headers):
             data2[name] = x['properties']['ucldc_schema:temporalcoverage'][
                 tempnumb]
             tempnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Temporal Coverage 1'] = ''
 
 
@@ -440,7 +445,7 @@ def get_transcription(data2, x, all_headers):
     if x['properties']['ucldc_schema:transcription'] != None and x[
             'properties']['ucldc_schema:transcription'] != '':
         data2['Transcription'] = x['properties']['ucldc_schema:transcription']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Transcription'] = ''
 
 
@@ -449,7 +454,7 @@ def get_access_restrictions(data2, x, all_headers):
             'properties']['ucldc_schema:accessrestrict'] != '':
         data2['Access Restrictions'] = x['properties'][
             'ucldc_schema:accessrestrict']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Access Restrictions'] = ''
 
 
@@ -458,7 +463,7 @@ def get_rights_statement(data2, x, all_headers):
             'properties']['ucldc_schema:rightsstatement'] != '':
         data2['Copyright Statement'] = x['properties'][
             'ucldc_schema:rightsstatement']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Statement'] = ''
 
 
@@ -467,7 +472,7 @@ def get_rights_status(data2, x, all_headers):
             'properties']['ucldc_schema:rightsstatus'] != '':
         data2['Copyright Status'] = x['properties'][
             'ucldc_schema:rightsstatus']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Status'] = ''
 
 
@@ -485,7 +490,7 @@ def get_copyright_holder(data2, x, all_headers):
                                 'name'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
                         rightsnumb]['name']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -497,7 +502,7 @@ def get_copyright_holder(data2, x, all_headers):
                                 'nametype'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
                         rightsnumb]['nametype']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -509,7 +514,7 @@ def get_copyright_holder(data2, x, all_headers):
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
                         rightsnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -521,12 +526,12 @@ def get_copyright_holder(data2, x, all_headers):
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:rightsholder'][
                         rightsnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             rightsnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Holder 1 Name'] = ''
         data2['Copyright Holder 1 Name Type'] = ''
         data2['Copyright Holder 1 Source'] = ''
@@ -538,48 +543,48 @@ def get_copyright_info(data2, x, all_headers):
             'properties']['ucldc_schema:rightscontact'] != '':
         data2['Copyright Contact'] = x['properties'][
             'ucldc_schema:rightscontact']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Contact'] = ''
 
     if x['properties']['ucldc_schema:rightsnotice'] != None and x[
             'properties']['ucldc_schema:rightsnotice'] != '':
         data2['Copyright Notice'] = x['properties'][
             'ucldc_schema:rightsnotice']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Notice'] = ''
 
     if x['properties']['ucldc_schema:rightsdeterminationdate'] != None and x[
             'properties']['ucldc_schema:rightsdeterminationdate'] != '':
         data2['Copyright Determination Date'] = x['properties'][
             'ucldc_schema:rightsdeterminationdate']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Determination Date'] = ''
 
     if x['properties']['ucldc_schema:rightsstartdate'] != None and x[
             'properties']['ucldc_schema:rightsstartdate'] != '':
         data2['Copyright Start Date'] = x['properties'][
             'ucldc_schema:rightsstartdate']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Start Date'] = ''
 
     if x['properties']['ucldc_schema:rightsenddate'] != None and x[
             'properties']['ucldc_schema:rightsenddate'] != '':
         data2['Copyright End Date'] = x['properties'][
             'ucldc_schema:rightsenddate']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright End Date'] = ''
 
     if x['properties']['ucldc_schema:rightsjurisdiction'] != None and x[
             'properties']['ucldc_schema:rightsjurisdiction'] != '':
         data2['Copyright Jurisdiction'] = x['properties'][
             'ucldc_schema:rightsjurisdiction']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Jurisdiction'] = ''
 
     if x['properties']['ucldc_schema:rightsnote'] != None and x['properties'][
             'ucldc_schema:rightsnote'] != '':
         data2['Copyright Note'] = x['properties']['ucldc_schema:rightsnote']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Copyright Note'] = ''
 
 
@@ -592,7 +597,7 @@ def get_collection(data2, x, all_headers):
             name = 'Collection %d' % numb
             data2[name] = x['properties']['ucldc_schema:collection'][collnumb]
             collnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Collection 1'] = ''
 
 
@@ -606,7 +611,7 @@ def get_related_resource(data2, x, all_headers):
             data2[name] = x['properties']['ucldc_schema:relatedresource'][
                 relnumb]
             relnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Related Resource 1'] = ''
 
 
@@ -614,7 +619,7 @@ def get_source(data2, x, all_headers):
     if x['properties']['ucldc_schema:source'] != None and x['properties'][
             'ucldc_schema:source'] != '':
         data2['Source'] = x['properties']['ucldc_schema:source']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Source'] = ''
 
 
@@ -631,7 +636,7 @@ def get_subject_name(data2, x, all_headers):
                             'ucldc_schema:subjectname'][subnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['name']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -643,7 +648,7 @@ def get_subject_name(data2, x, all_headers):
                                 'name_type'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['name_type']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -654,7 +659,7 @@ def get_subject_name(data2, x, all_headers):
                             'ucldc_schema:subjectname'][subnumb]['role'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['role']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -666,7 +671,7 @@ def get_subject_name(data2, x, all_headers):
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -678,12 +683,12 @@ def get_subject_name(data2, x, all_headers):
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjectname'][
                         subnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             subnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Subject (Name) 1 Name'] = ''
         data2['Subject (Name) 1 Name Type'] = ''
         data2['Subject (Name) 1 Role'] = ''
@@ -704,7 +709,7 @@ def get_place(data2, x, all_headers):
                             'ucldc_schema:place'][plcnumb]['name'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['name']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -715,7 +720,7 @@ def get_place(data2, x, all_headers):
                             'ucldc_schema:place'][plcnumb]['coordinates'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['coordinates']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -726,7 +731,7 @@ def get_place(data2, x, all_headers):
                             'ucldc_schema:place'][plcnumb]['source'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -737,12 +742,12 @@ def get_place(data2, x, all_headers):
                             'ucldc_schema:place'][plcnumb]['authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:place'][
                         plcnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             plcnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Place 1 Name'] = ''
         data2['Place 1 Coordinates'] = ''
         data2['Place 1 Source'] = ''
@@ -763,7 +768,7 @@ def get_subject_topic(data2, x, all_headers):
                                 'heading'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
                         topnumb]['heading']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -775,7 +780,7 @@ def get_subject_topic(data2, x, all_headers):
                                 'headingtype'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
                         topnumb]['headingtype']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -787,7 +792,7 @@ def get_subject_topic(data2, x, all_headers):
                                 'source'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
                         topnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -799,12 +804,12 @@ def get_subject_topic(data2, x, all_headers):
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:subjecttopic'][
                         topnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             topnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Subject (Topic) 1 Heading'] = ''
         data2['Subject (Topic) 1 Heading Type'] = ''
         data2['Subject (Topic) 1 Source'] = ''
@@ -825,7 +830,7 @@ def get_form_genre(data2, x, all_headers):
                                 'heading'] != '':
                     data2[name] = x['properties']['ucldc_schema:formgenre'][
                         formnumb]['heading']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -836,7 +841,7 @@ def get_form_genre(data2, x, all_headers):
                             'ucldc_schema:formgenre'][formnumb]['source'] != '':
                     data2[name] = x['properties']['ucldc_schema:formgenre'][
                         formnumb]['source']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
@@ -848,12 +853,12 @@ def get_form_genre(data2, x, all_headers):
                                 'authorityid'] != '':
                     data2[name] = x['properties']['ucldc_schema:formgenre'][
                         formnumb]['authorityid']
-                elif all_headers == 'y' or all_headers == 'Y':
+                elif all_headers == 'y':
                     data2[name] = ''
             except:
                 pass
             formnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Form/Genre 1 Heading'] = ''
         data2['Form/Genre 1 Source'] = ''
         data2['Form/Genre 1 Authority ID'] = ''
@@ -868,7 +873,7 @@ def get_provenance(data2, x, all_headers):
             name = 'Provenance %d' % numb
             data2[name] = x['properties']['ucldc_schema:provenance'][provnumb]
             provnumb += 1
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Provenance 1'] = ''
 
 
@@ -877,7 +882,7 @@ def get_physical_location(data2, x, all_headers):
             'properties']['ucldc_schema:physlocation'] != '':
         data2['Physical Location'] = x['properties'][
             'ucldc_schema:physlocation']
-    elif all_headers == 'y' or all_headers == 'Y':
+    elif all_headers == 'y':
         data2['Physical Location'] = ''
 
 

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -4,8 +4,10 @@
 #it also allows for metadata to be downloaded from the collection or item level
 #it also asks if all headers should be downloaded or if the empty items should not be downloaded
 #Nuxeo has to be installed for this script to work
-import unicodecsv as csv
 import os
+import unicodecsv as csv
+from pynux import utils
+
 try:
     filepath = raw_input('Enter Nuxeo File Path: ')
 except:
@@ -22,8 +24,6 @@ try:
     all_headers = raw_input('All Headers? (Y/N): ')
 except:
     all_headers = input('All Headers? (Y/N): ')
-
-from pynux import utils
 
 
 def get_title(data2, x):  #gets title

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -18,6 +18,8 @@ import os
 import argparse
 import unicodecsv as csv
 from pynux import utils
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
 
 
 def main():
@@ -53,131 +55,167 @@ def main():
     all_headers = args.all_headers
     gsheets_url = args.sheet.strip()
 
-    google_error_text = (
-        "\n*********\nWriting to Google document did not work."
-        "Make sure that Google document has been shared "
-        "with API key email address")
+    nx = utils.Nuxeo()
 
+    # google_error_text = (
+    #     "\n*********\nWriting to Google document did not work."
+    #     "Make sure that Google document has been shared "
+    #     "with API key email address")
+
+    data = []
     if item_level:
-        if gsheets_url:
-            try:
-                google_item(nuxeo_top_path, all_headers, gsheets_url)
-            except:
-                print(google_error_text)
-        else:
-            item = get_data_item_level(nuxeo_top_path, all_headers)
-            with open(item["filename"], "wb") as csvfile:
-                writer = csv.DictWriter(csvfile,
-                                        fieldnames=item["fieldnames"],
-                                        delimiter="\t")
-                writer.writeheader()
-                for row in item["data"]:
-                    writer.writerow(row)
+        for obj in nx.children(nuxeo_top_path):
+            for item in nx.children(obj["path"]):
+                metadata_row = process_metadata(item, all_headers)
+                data.append(metadata_row)
+    else:
+        for obj in nx.children(nuxeo_top_path):
+            metadata_row = process_metadata(obj, all_headers)
+            data.append(metadata_row)
+
+    fieldnames = sort_fieldnames(data)
+    sheet_name = nuxeo_top_path.split("/")[-1]
+
+    if gsheets_url:
+        write_gsheet(data, sheet_name, fieldnames, gsheets_url)
 
     else:
-        if gsheets_url:
-            try:
-                google_object(nuxeo_top_path, all_headers, gsheets_url)
-            except:
-                print(google_error_text)
-        else:
-            obj = get_data_object_level(nuxeo_top_path, all_headers)
-            with open(obj["filename"], "wb") as csvfile:
-                writer = csv.DictWriter(csvfile,
-                                        fieldnames=obj["fieldnames"],
-                                        delimiter="\t")
-                writer.writeheader()
-                for row in obj["data"]:
-                    writer.writerow(row)
+        sheet_name += ".tsv"
+        write_csv(data, sheet_name, fieldnames, delimiter="\t")
 
 
-def get_title(data2, x):
+def process_metadata(nxdoc, all_headers):
+    """ map Nuxeo JSON to flat data structure with human-readable labels
+    """
+
+    data2 = {}
+
+    get_title(data2, nxdoc)
+    get_filepath(data2, nxdoc)
+    get_type(data2, nxdoc, all_headers)
+    get_alt_title(data2, nxdoc, all_headers)
+    get_identifier(data2, nxdoc, all_headers)
+    get_local_identifier(data2, nxdoc, all_headers)
+    get_campus_unit(data2, nxdoc, all_headers)
+    get_date(data2, nxdoc, all_headers)
+    get_publication(data2, nxdoc, all_headers)
+    get_creator(data2, nxdoc, all_headers)
+    get_contributor(data2, nxdoc, all_headers)
+    get_format(data2, nxdoc, all_headers)
+    get_description(data2, nxdoc, all_headers)
+    get_extent(data2, nxdoc, all_headers)
+    get_language(data2, nxdoc, all_headers)
+    get_temporal_coverage(data2, nxdoc, all_headers)
+    get_transcription(data2, nxdoc, all_headers)
+    get_access_restrictions(data2, nxdoc, all_headers)
+    get_rights_statement(data2, nxdoc, all_headers)
+    get_rights_status(data2, nxdoc, all_headers)
+    get_copyright_holder(data2, nxdoc, all_headers)
+    get_copyright_info(data2, nxdoc, all_headers)
+    get_collection(data2, nxdoc, all_headers)
+    get_related_resource(data2, nxdoc, all_headers)
+    get_source(data2, nxdoc, all_headers)
+    get_subject_name(data2, nxdoc, all_headers)
+    get_place(data2, nxdoc, all_headers)
+    get_subject_topic(data2, nxdoc, all_headers)
+    get_form_genre(data2, nxdoc, all_headers)
+    get_provenance(data2, nxdoc, all_headers)
+    get_physical_location(data2, nxdoc, all_headers)
+
+    return data2
+
+
+def get_title(data2, nxdoc):
     """gets title
     """
-    data2["Title"] = x["properties"]["dc:title"]
+    data2["Title"] = nxdoc["properties"]["dc:title"]
 
 
-def get_filepath(data2, x):
+def get_filepath(data2, nxdoc):
     """gets filepath
     """
-    data2["File path"] = x["path"]
+    data2["File path"] = nxdoc["path"]
 
 
-def get_type(data2, x, all_headers):
+def get_type(data2, nxdoc, all_headers):
     """gets type,
-    inputs are dictionary (data2), nuxeo (x), all_headers input
+    inputs are dictionary (data2), nuxeo (nxdoc), all_headers input
     """
-    if x["properties"]["ucldc_schema:type"] is not None and x["properties"][
-            "ucldc_schema:type"] != "":
-        data2["Type"] = x["properties"]["ucldc_schema:type"]
+    if nxdoc["properties"]["ucldc_schema:type"] is not None and nxdoc[
+            "properties"]["ucldc_schema:type"] != "":
+        data2["Type"] = nxdoc["properties"]["ucldc_schema:type"]
     elif all_headers == "y":
         data2["Type"] = ""
 
 
-def get_alt_title(data2, x, all_headers):
+def get_alt_title(data2, nxdoc, all_headers):
     altnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:alternativetitle"],
-                  list) and len(
-                      x["properties"]["ucldc_schema:alternativetitle"]) > 0:
-        while altnumb < len(x["properties"]["ucldc_schema:alternativetitle"]):
+    if isinstance(
+            nxdoc["properties"]["ucldc_schema:alternativetitle"],
+            list) and len(
+                nxdoc["properties"]["ucldc_schema:alternativetitle"]) > 0:
+        while altnumb < len(
+                nxdoc["properties"]["ucldc_schema:alternativetitle"]):
             numb = altnumb + 1
             name = "Alternative Title %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:alternativetitle"][
+            data2[name] = nxdoc["properties"]["ucldc_schema:alternativetitle"][
                 altnumb]
             altnumb += 1
     elif all_headers == "y":
         data2["Alternative Title 1"] = ""
 
 
-def get_identifier(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:identifier"] is not None and x[
+def get_identifier(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:identifier"] is not None and nxdoc[
             "properties"]["ucldc_schema:identifier"] != "":
-        data2["Identifier"] = x["properties"]["ucldc_schema:identifier"]
+        data2["Identifier"] = nxdoc["properties"]["ucldc_schema:identifier"]
     elif all_headers == "y":
         data2["Identifier"] = ""
 
 
-def get_local_identifier(data2, x, all_headers):
+def get_local_identifier(data2, nxdoc, all_headers):
     locnumb = 0
-    if isinstance(
-            x["properties"]["ucldc_schema:localidentifier"],
-            list) and len(x["properties"]["ucldc_schema:localidentifier"]) > 0:
-        while locnumb < len(x["properties"]["ucldc_schema:localidentifier"]):
+    if isinstance(nxdoc["properties"]["ucldc_schema:localidentifier"],
+                  list) and len(
+                      nxdoc["properties"]["ucldc_schema:localidentifier"]) > 0:
+        while locnumb < len(
+                nxdoc["properties"]["ucldc_schema:localidentifier"]):
             numb = locnumb + 1
             name = "Local Identifier %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:localidentifier"][
+            data2[name] = nxdoc["properties"]["ucldc_schema:localidentifier"][
                 locnumb]
             locnumb += 1
     elif all_headers == "y":
         data2["Local Identifier 1"] = ""
 
 
-def get_campus_unit(data2, x, all_headers):
+def get_campus_unit(data2, nxdoc, all_headers):
     campnumb = 0
     if isinstance(
-            x["properties"]["ucldc_schema:campusunit"],
-            list) and len(x["properties"]["ucldc_schema:campusunit"]) > 0:
-        while campnumb < len(x["properties"]["ucldc_schema:campusunit"]):
+            nxdoc["properties"]["ucldc_schema:campusunit"],
+            list) and len(nxdoc["properties"]["ucldc_schema:campusunit"]) > 0:
+        while campnumb < len(nxdoc["properties"]["ucldc_schema:campusunit"]):
             numb = campnumb + 1
             name = "Campus/Unit %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:campusunit"][campnumb]
+            data2[name] = nxdoc["properties"]["ucldc_schema:campusunit"][
+                campnumb]
             campnumb += 1
     elif all_headers == "y":
         data2["Campus/Unit 1"] = ""
 
 
-def get_date(data2, x, all_headers):
+def get_date(data2, nxdoc, all_headers):
     datenumb = 0
-    if isinstance(x["properties"]["ucldc_schema:date"],
-                  list) and len(x["properties"]["ucldc_schema:date"]) > 0:
-        while datenumb < len(x["properties"]["ucldc_schema:date"]):
+    if isinstance(nxdoc["properties"]["ucldc_schema:date"],
+                  list) and len(nxdoc["properties"]["ucldc_schema:date"]) > 0:
+        while datenumb < len(nxdoc["properties"]["ucldc_schema:date"]):
             numb = datenumb + 1
             try:
                 name = "Date %d" % numb
-                if x["properties"]["ucldc_schema:date"][datenumb][
-                        "date"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
+                        "date"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb]["date"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:date"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["date"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -185,10 +223,10 @@ def get_date(data2, x, all_headers):
                 pass
             try:
                 name = "Date %d Type" % numb
-                if x["properties"]["ucldc_schema:date"][datenumb][
-                        "datetype"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
+                        "datetype"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb]["datetype"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:date"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["datetype"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -196,11 +234,11 @@ def get_date(data2, x, all_headers):
                 pass
             try:
                 name = "Date %d Inclusive Start" % numb
-                if x["properties"]["ucldc_schema:date"][datenumb][
-                        "inclusivestart"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
+                        "inclusivestart"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb][
                                 "inclusivestart"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:date"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["inclusivestart"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -208,11 +246,11 @@ def get_date(data2, x, all_headers):
                 pass
             try:
                 name = "Date %d Inclusive End" % numb
-                if x["properties"]["ucldc_schema:date"][datenumb][
-                        "inclusiveend"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
+                        "inclusiveend"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb][
                                 "inclusiveend"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:date"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["inclusiveend"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -220,10 +258,10 @@ def get_date(data2, x, all_headers):
                 pass
             try:
                 name = "Date %d Single" % numb
-                if x["properties"]["ucldc_schema:date"][datenumb][
-                        "single"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:date"][datenumb][
+                        "single"] is not None and nxdoc["properties"][
                             "ucldc_schema:date"][datenumb]["single"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:date"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["single"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -238,31 +276,34 @@ def get_date(data2, x, all_headers):
         data2["Date 1 Single"] = ""
 
 
-def get_publication(data2, x, all_headers):
+def get_publication(data2, nxdoc, all_headers):
     pubnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:publisher"],
-                  list) and len(x["properties"]["ucldc_schema:publisher"]) > 0:
-        while pubnumb < len(x["properties"]["ucldc_schema:publisher"]):
+    if isinstance(
+            nxdoc["properties"]["ucldc_schema:publisher"],
+            list) and len(nxdoc["properties"]["ucldc_schema:publisher"]) > 0:
+        while pubnumb < len(nxdoc["properties"]["ucldc_schema:publisher"]):
             numb = pubnumb + 1
             name = "Publication/Origination Info %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:publisher"][pubnumb]
+            data2[name] = nxdoc["properties"]["ucldc_schema:publisher"][
+                pubnumb]
             pubnumb += 1
     elif all_headers == "y":
         data2["Publication/Origination Info 1"] = ""
 
 
-def get_creator(data2, x, all_headers):
+def get_creator(data2, nxdoc, all_headers):
     creatnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:creator"],
-                  list) and len(x["properties"]["ucldc_schema:creator"]) > 0:
-        while creatnumb < len(x["properties"]["ucldc_schema:creator"]):
+    if isinstance(
+            nxdoc["properties"]["ucldc_schema:creator"],
+            list) and len(nxdoc["properties"]["ucldc_schema:creator"]) > 0:
+        while creatnumb < len(nxdoc["properties"]["ucldc_schema:creator"]):
             numb = creatnumb + 1
             try:
                 name = "Creator %d Name" % numb
-                if x["properties"]["ucldc_schema:creator"][creatnumb][
-                        "name"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
+                        "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb]["name"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["name"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -270,11 +311,11 @@ def get_creator(data2, x, all_headers):
                 pass
             try:
                 name = "Creator %d Name Type" % numb
-                if x["properties"]["ucldc_schema:creator"][creatnumb][
-                        "nametype"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
+                        "nametype"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb][
                                 "nametype"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["nametype"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -282,10 +323,10 @@ def get_creator(data2, x, all_headers):
                 pass
             try:
                 name = "Creator %d Role" % numb
-                if x["properties"]["ucldc_schema:creator"][creatnumb][
-                        "role"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
+                        "role"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb]["role"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["role"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -293,10 +334,10 @@ def get_creator(data2, x, all_headers):
                 pass
             try:
                 name = "Creator %d Source" % numb
-                if x["properties"]["ucldc_schema:creator"][creatnumb][
-                        "source"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
+                        "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb]["source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -304,11 +345,11 @@ def get_creator(data2, x, all_headers):
                 pass
             try:
                 name = "Creator %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:creator"][creatnumb][
-                        "authorityid"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:creator"][creatnumb][
+                        "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:creator"][creatnumb][
                                 "authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:creator"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -323,67 +364,67 @@ def get_creator(data2, x, all_headers):
         data2["Creator 1 Authority ID"] = ""
 
 
-def get_contributor(data2, x, all_headers):
+def get_contributor(data2, nxdoc, all_headers):
     contnumb = 0
     if isinstance(
-            x["properties"]["ucldc_schema:contributor"],
-            list) and len(x["properties"]["ucldc_schema:contributor"]) > 0:
-        while contnumb < len(x["properties"]["ucldc_schema:contributor"]):
+            nxdoc["properties"]["ucldc_schema:contributor"],
+            list) and len(nxdoc["properties"]["ucldc_schema:contributor"]) > 0:
+        while contnumb < len(nxdoc["properties"]["ucldc_schema:contributor"]):
             numb = contnumb + 1
             try:
                 name = "Contributor %d Name" % numb
-                if x["properties"]["ucldc_schema:contributor"][contnumb][
-                        "name"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
+                        "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb]["name"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:contributor"][
-                        contnumb]["name"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:contributor"][contnumb]["name"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Contributor %d Name Type" % numb
-                if x["properties"]["ucldc_schema:contributor"][contnumb][
-                        "nametype"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
+                        "nametype"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb][
                                 "nametype"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:contributor"][
-                        contnumb]["nametype"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:contributor"][contnumb]["nametype"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Contributor %d Role" % numb
-                if x["properties"]["ucldc_schema:contributor"][contnumb][
-                        "role"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
+                        "role"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb]["role"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:contributor"][
-                        contnumb]["role"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:contributor"][contnumb]["role"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Contributor %d Source" % numb
-                if x["properties"]["ucldc_schema:contributor"][contnumb][
-                        "source"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
+                        "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb][
                                 "source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:contributor"][
-                        contnumb]["source"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:contributor"][contnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Contributor %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:contributor"][contnumb][
-                        "authorityid"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:contributor"][contnumb][
+                        "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:contributor"][contnumb][
                                 "authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:contributor"][
-                        contnumb]["authorityid"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:contributor"][contnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
@@ -397,40 +438,40 @@ def get_contributor(data2, x, all_headers):
         data2["Contributor 1 Authority ID"] = ""
 
 
-def get_format(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:physdesc"] is not None and x[
+def get_format(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:physdesc"] is not None and nxdoc[
             "properties"]["ucldc_schema:physdesc"] != "":
-        data2["Format/Physical Description"] = x["properties"][
+        data2["Format/Physical Description"] = nxdoc["properties"][
             "ucldc_schema:physdesc"]
     elif all_headers == "y":
         data2["Format/Physical Description"] = ""
 
 
-def get_description(data2, x, all_headers):
+def get_description(data2, nxdoc, all_headers):
     descnumb = 0
     if isinstance(
-            x["properties"]["ucldc_schema:description"],
-            list) and len(x["properties"]["ucldc_schema:description"]) > 0:
-        while descnumb < len(x["properties"]["ucldc_schema:description"]):
+            nxdoc["properties"]["ucldc_schema:description"],
+            list) and len(nxdoc["properties"]["ucldc_schema:description"]) > 0:
+        while descnumb < len(nxdoc["properties"]["ucldc_schema:description"]):
             numb = descnumb + 1
             try:
                 name = "Description %d Note" % numb
-                if x["properties"]["ucldc_schema:description"][descnumb][
-                        "item"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:description"][descnumb][
+                        "item"] is not None and nxdoc["properties"][
                             "ucldc_schema:description"][descnumb]["item"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:description"][
-                        descnumb]["item"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:description"][descnumb]["item"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Description %d Type" % numb
-                if x["properties"]["ucldc_schema:description"][descnumb][
-                        "type"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:description"][descnumb][
+                        "type"] is not None and nxdoc["properties"][
                             "ucldc_schema:description"][descnumb]["type"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:description"][
-                        descnumb]["type"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:description"][descnumb]["type"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
@@ -441,27 +482,28 @@ def get_description(data2, x, all_headers):
         data2["Description 1 Type"] = ""
 
 
-def get_extent(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:extent"] is not None and x["properties"][
-            "ucldc_schema:extent"] != "":
-        data2["Extent"] = x["properties"]["ucldc_schema:extent"]
+def get_extent(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:extent"] is not None and nxdoc[
+            "properties"]["ucldc_schema:extent"] != "":
+        data2["Extent"] = nxdoc["properties"]["ucldc_schema:extent"]
     elif all_headers == "y":
         data2["Extent"] = ""
 
 
-def get_language(data2, x, all_headers):
+def get_language(data2, nxdoc, all_headers):
     langnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:language"],
-                  list) and len(x["properties"]["ucldc_schema:language"]) > 0:
-        while langnumb < len(x["properties"]["ucldc_schema:language"]):
+    if isinstance(
+            nxdoc["properties"]["ucldc_schema:language"],
+            list) and len(nxdoc["properties"]["ucldc_schema:language"]) > 0:
+        while langnumb < len(nxdoc["properties"]["ucldc_schema:language"]):
             numb = langnumb + 1
             try:
                 name = "Language %d" % numb
-                if x["properties"]["ucldc_schema:language"][langnumb][
-                        "language"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:language"][langnumb][
+                        "language"] is not None and nxdoc["properties"][
                             "ucldc_schema:language"][langnumb][
                                 "language"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:language"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:language"][
                         langnumb]["language"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -469,11 +511,11 @@ def get_language(data2, x, all_headers):
                 pass
             try:
                 name = "Language %d Code" % numb
-                if x["properties"]["ucldc_schema:language"][langnumb][
-                        "languagecode"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:language"][langnumb][
+                        "languagecode"] is not None and nxdoc["properties"][
                             "ucldc_schema:language"][langnumb][
                                 "languagecode"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:language"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:language"][
                         langnumb]["languagecode"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -485,107 +527,112 @@ def get_language(data2, x, all_headers):
         data2["Language 1 Code"] = ""
 
 
-def get_temporal_coverage(data2, x, all_headers):
+def get_temporal_coverage(data2, nxdoc, all_headers):
     tempnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:temporalcoverage"],
-                  list) and len(
-                      x["properties"]["ucldc_schema:temporalcoverage"]) > 0:
-        while tempnumb < len(x["properties"]["ucldc_schema:temporalcoverage"]):
+    if isinstance(
+            nxdoc["properties"]["ucldc_schema:temporalcoverage"],
+            list) and len(
+                nxdoc["properties"]["ucldc_schema:temporalcoverage"]) > 0:
+        while tempnumb < len(
+                nxdoc["properties"]["ucldc_schema:temporalcoverage"]):
             numb = tempnumb + 1
             name = "Temporal Coverage %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:temporalcoverage"][
+            data2[name] = nxdoc["properties"]["ucldc_schema:temporalcoverage"][
                 tempnumb]
             tempnumb += 1
     elif all_headers == "y":
         data2["Temporal Coverage 1"] = ""
 
 
-def get_transcription(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:transcription"] is not None and x[
+def get_transcription(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:transcription"] is not None and nxdoc[
             "properties"]["ucldc_schema:transcription"] != "":
-        data2["Transcription"] = x["properties"]["ucldc_schema:transcription"]
+        data2["Transcription"] = nxdoc["properties"][
+            "ucldc_schema:transcription"]
     elif all_headers == "y":
         data2["Transcription"] = ""
 
 
-def get_access_restrictions(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:accessrestrict"] is not None and x[
+def get_access_restrictions(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:accessrestrict"] is not None and nxdoc[
             "properties"]["ucldc_schema:accessrestrict"] != "":
-        data2["Access Restrictions"] = x["properties"][
+        data2["Access Restrictions"] = nxdoc["properties"][
             "ucldc_schema:accessrestrict"]
     elif all_headers == "y":
         data2["Access Restrictions"] = ""
 
 
-def get_rights_statement(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:rightsstatement"] is not None and x[
-            "properties"]["ucldc_schema:rightsstatement"] != "":
-        data2["Copyright Statement"] = x["properties"][
+def get_rights_statement(data2, nxdoc, all_headers):
+    if nxdoc["properties"][
+            "ucldc_schema:rightsstatement"] is not None and nxdoc[
+                "properties"]["ucldc_schema:rightsstatement"] != "":
+        data2["Copyright Statement"] = nxdoc["properties"][
             "ucldc_schema:rightsstatement"]
     elif all_headers == "y":
         data2["Copyright Statement"] = ""
 
 
-def get_rights_status(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:rightsstatus"] is not None and x[
+def get_rights_status(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:rightsstatus"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsstatus"] != "":
-        data2["Copyright Status"] = x["properties"][
+        data2["Copyright Status"] = nxdoc["properties"][
             "ucldc_schema:rightsstatus"]
     elif all_headers == "y":
         data2["Copyright Status"] = ""
 
 
-def get_copyright_holder(data2, x, all_headers):
+def get_copyright_holder(data2, nxdoc, all_headers):
     rightsnumb = 0
-    if isinstance(
-            x["properties"]["ucldc_schema:rightsholder"],
-            list) and len(x["properties"]["ucldc_schema:rightsholder"]) > 0:
-        while rightsnumb < len(x["properties"]["ucldc_schema:rightsholder"]):
+    if isinstance(nxdoc["properties"]["ucldc_schema:rightsholder"],
+                  list) and len(
+                      nxdoc["properties"]["ucldc_schema:rightsholder"]) > 0:
+        while rightsnumb < len(
+                nxdoc["properties"]["ucldc_schema:rightsholder"]):
             numb = rightsnumb + 1
             try:
                 name = "Copyright Holder %d Name" % numb
-                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
-                        "name"] is not None and x["properties"][
-                            "ucldc_schema:rightsholder"][rightsnumb][
-                                "name"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["name"]
+                if nxdoc["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["name"] is not None and nxdoc[
+                            "properties"]["ucldc_schema:rightsholder"][
+                                rightsnumb]["name"] != "":
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:rightsholder"][rightsnumb]["name"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Copyright Holder %d Name Type" % numb
-                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
-                        "nametype"] is not None and x["properties"][
-                            "ucldc_schema:rightsholder"][rightsnumb][
-                                "nametype"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["nametype"]
+                if nxdoc["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["nametype"] is not None and nxdoc[
+                            "properties"]["ucldc_schema:rightsholder"][
+                                rightsnumb]["nametype"] != "":
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:rightsholder"][rightsnumb]["nametype"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Copyright Holder %d Source" % numb
-                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
-                        "source"] is not None and x["properties"][
-                            "ucldc_schema:rightsholder"][rightsnumb][
-                                "source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["source"]
+                if nxdoc["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["source"] is not None and nxdoc[
+                            "properties"]["ucldc_schema:rightsholder"][
+                                rightsnumb]["source"] != "":
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:rightsholder"][rightsnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Copyright Holder %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:rightsholder"][rightsnumb][
-                        "authorityid"] is not None and x["properties"][
-                            "ucldc_schema:rightsholder"][rightsnumb][
-                                "authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:rightsholder"][
-                        rightsnumb]["authorityid"]
+                if nxdoc["properties"]["ucldc_schema:rightsholder"][
+                        rightsnumb]["authorityid"] is not None and nxdoc[
+                            "properties"]["ucldc_schema:rightsholder"][
+                                rightsnumb]["authorityid"] != "":
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:rightsholder"][rightsnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
@@ -598,155 +645,160 @@ def get_copyright_holder(data2, x, all_headers):
         data2["Copyright Holder 1 Authority ID"] = ""
 
 
-def get_copyright_info(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:rightscontact"] is not None and x[
+def get_copyright_info(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:rightscontact"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightscontact"] != "":
-        data2["Copyright Contact"] = x["properties"][
+        data2["Copyright Contact"] = nxdoc["properties"][
             "ucldc_schema:rightscontact"]
     elif all_headers == "y":
         data2["Copyright Contact"] = ""
 
-    if x["properties"]["ucldc_schema:rightsnotice"] is not None and x[
+    if nxdoc["properties"]["ucldc_schema:rightsnotice"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsnotice"] != "":
-        data2["Copyright Notice"] = x["properties"][
+        data2["Copyright Notice"] = nxdoc["properties"][
             "ucldc_schema:rightsnotice"]
     elif all_headers == "y":
         data2["Copyright Notice"] = ""
 
-    if x["properties"][
-            "ucldc_schema:rightsdeterminationdate"] is not None and x[
+    if nxdoc["properties"][
+            "ucldc_schema:rightsdeterminationdate"] is not None and nxdoc[
                 "properties"]["ucldc_schema:rightsdeterminationdate"] != "":
-        data2["Copyright Determination Date"] = x["properties"][
+        data2["Copyright Determination Date"] = nxdoc["properties"][
             "ucldc_schema:rightsdeterminationdate"]
     elif all_headers == "y":
         data2["Copyright Determination Date"] = ""
 
-    if x["properties"]["ucldc_schema:rightsstartdate"] is not None and x[
-            "properties"]["ucldc_schema:rightsstartdate"] != "":
-        data2["Copyright Start Date"] = x["properties"][
+    if nxdoc["properties"][
+            "ucldc_schema:rightsstartdate"] is not None and nxdoc[
+                "properties"]["ucldc_schema:rightsstartdate"] != "":
+        data2["Copyright Start Date"] = nxdoc["properties"][
             "ucldc_schema:rightsstartdate"]
     elif all_headers == "y":
         data2["Copyright Start Date"] = ""
 
-    if x["properties"]["ucldc_schema:rightsenddate"] is not None and x[
+    if nxdoc["properties"]["ucldc_schema:rightsenddate"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsenddate"] != "":
-        data2["Copyright End Date"] = x["properties"][
+        data2["Copyright End Date"] = nxdoc["properties"][
             "ucldc_schema:rightsenddate"]
     elif all_headers == "y":
         data2["Copyright End Date"] = ""
 
-    if x["properties"]["ucldc_schema:rightsjurisdiction"] is not None and x[
-            "properties"]["ucldc_schema:rightsjurisdiction"] != "":
-        data2["Copyright Jurisdiction"] = x["properties"][
+    if nxdoc["properties"][
+            "ucldc_schema:rightsjurisdiction"] is not None and nxdoc[
+                "properties"]["ucldc_schema:rightsjurisdiction"] != "":
+        data2["Copyright Jurisdiction"] = nxdoc["properties"][
             "ucldc_schema:rightsjurisdiction"]
     elif all_headers == "y":
         data2["Copyright Jurisdiction"] = ""
 
-    if x["properties"]["ucldc_schema:rightsnote"] is not None and x[
+    if nxdoc["properties"]["ucldc_schema:rightsnote"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsnote"] != "":
-        data2["Copyright Note"] = x["properties"]["ucldc_schema:rightsnote"]
+        data2["Copyright Note"] = nxdoc["properties"][
+            "ucldc_schema:rightsnote"]
     elif all_headers == "y":
         data2["Copyright Note"] = ""
 
 
-def get_collection(data2, x, all_headers):
+def get_collection(data2, nxdoc, all_headers):
     collnumb = 0
     if isinstance(
-            x["properties"]["ucldc_schema:collection"],
-            list) and len(x["properties"]["ucldc_schema:collection"]) > 0:
-        while collnumb < len(x["properties"]["ucldc_schema:collection"]):
+            nxdoc["properties"]["ucldc_schema:collection"],
+            list) and len(nxdoc["properties"]["ucldc_schema:collection"]) > 0:
+        while collnumb < len(nxdoc["properties"]["ucldc_schema:collection"]):
             numb = collnumb + 1
             name = "Collection %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:collection"][collnumb]
+            data2[name] = nxdoc["properties"]["ucldc_schema:collection"][
+                collnumb]
             collnumb += 1
     elif all_headers == "y":
         data2["Collection 1"] = ""
 
 
-def get_related_resource(data2, x, all_headers):
+def get_related_resource(data2, nxdoc, all_headers):
     relnumb = 0
-    if isinstance(
-            x["properties"]["ucldc_schema:relatedresource"],
-            list) and len(x["properties"]["ucldc_schema:relatedresource"]) > 0:
-        while relnumb < len(x["properties"]["ucldc_schema:relatedresource"]):
+    if isinstance(nxdoc["properties"]["ucldc_schema:relatedresource"],
+                  list) and len(
+                      nxdoc["properties"]["ucldc_schema:relatedresource"]) > 0:
+        while relnumb < len(
+                nxdoc["properties"]["ucldc_schema:relatedresource"]):
             numb = relnumb + 1
             name = "Related Resource %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:relatedresource"][
+            data2[name] = nxdoc["properties"]["ucldc_schema:relatedresource"][
                 relnumb]
             relnumb += 1
     elif all_headers == "y":
         data2["Related Resource 1"] = ""
 
 
-def get_source(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:source"] is not None and x["properties"][
-            "ucldc_schema:source"] != "":
-        data2["Source"] = x["properties"]["ucldc_schema:source"]
+def get_source(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:source"] is not None and nxdoc[
+            "properties"]["ucldc_schema:source"] != "":
+        data2["Source"] = nxdoc["properties"]["ucldc_schema:source"]
     elif all_headers == "y":
         data2["Source"] = ""
 
 
-def get_subject_name(data2, x, all_headers):
+def get_subject_name(data2, nxdoc, all_headers):
     subnumb = 0
     if isinstance(
-            x["properties"]["ucldc_schema:subjectname"],
-            list) and len(x["properties"]["ucldc_schema:subjectname"]) > 0:
-        while subnumb < len(x["properties"]["ucldc_schema:subjectname"]):
+            nxdoc["properties"]["ucldc_schema:subjectname"],
+            list) and len(nxdoc["properties"]["ucldc_schema:subjectname"]) > 0:
+        while subnumb < len(nxdoc["properties"]["ucldc_schema:subjectname"]):
             numb = subnumb + 1
             try:
                 name = "Subject (Name) %d Name" % numb
-                if x["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "name"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb]["name"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
-                        subnumb]["name"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjectname"][subnumb]["name"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Name) %d Name Type" % numb
-                if x["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "name_type"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "name_type"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb][
                                 "name_type"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
-                        subnumb]["name_type"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjectname"][subnumb]["name_type"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Name) %d Role" % numb
-                if x["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "role"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "role"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb]["role"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
-                        subnumb]["role"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjectname"][subnumb]["role"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Name) %d Source" % numb
-                if x["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "source"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb][
                                 "source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
-                        subnumb]["source"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjectname"][subnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Name) %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:subjectname"][subnumb][
-                        "authorityid"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjectname"][subnumb][
+                        "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjectname"][subnumb][
                                 "authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjectname"][
-                        subnumb]["authorityid"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjectname"][subnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
@@ -760,18 +812,18 @@ def get_subject_name(data2, x, all_headers):
         data2["Subject (Name) 1 Authority ID"] = ""
 
 
-def get_place(data2, x, all_headers):
+def get_place(data2, nxdoc, all_headers):
     plcnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:place"],
-                  list) and len(x["properties"]["ucldc_schema:place"]) > 0:
-        while plcnumb < len(x["properties"]["ucldc_schema:place"]):
+    if isinstance(nxdoc["properties"]["ucldc_schema:place"],
+                  list) and len(nxdoc["properties"]["ucldc_schema:place"]) > 0:
+        while plcnumb < len(nxdoc["properties"]["ucldc_schema:place"]):
             numb = plcnumb + 1
             try:
                 name = "Place %d Name" % numb
-                if x["properties"]["ucldc_schema:place"][plcnumb][
-                        "name"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
+                        "name"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["name"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:place"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["name"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -779,10 +831,10 @@ def get_place(data2, x, all_headers):
                 pass
             try:
                 name = "Place %d Coordinates" % numb
-                if x["properties"]["ucldc_schema:place"][plcnumb][
-                        "coordinates"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
+                        "coordinates"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["coordinates"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:place"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["coordinates"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -790,10 +842,10 @@ def get_place(data2, x, all_headers):
                 pass
             try:
                 name = "Place %d Source" % numb
-                if x["properties"]["ucldc_schema:place"][plcnumb][
-                        "source"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
+                        "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:place"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -801,10 +853,10 @@ def get_place(data2, x, all_headers):
                 pass
             try:
                 name = "Place %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:place"][plcnumb][
-                        "authorityid"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:place"][plcnumb][
+                        "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:place"][plcnumb]["authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:place"][
+                    data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
@@ -818,57 +870,57 @@ def get_place(data2, x, all_headers):
         data2["Place 1 Authority ID"] = ""
 
 
-def get_subject_topic(data2, x, all_headers):
+def get_subject_topic(data2, nxdoc, all_headers):
     topnumb = 0
-    if isinstance(
-            x["properties"]["ucldc_schema:subjecttopic"],
-            list) and len(x["properties"]["ucldc_schema:subjecttopic"]) > 0:
-        while topnumb < len(x["properties"]["ucldc_schema:subjecttopic"]):
+    if isinstance(nxdoc["properties"]["ucldc_schema:subjecttopic"],
+                  list) and len(
+                      nxdoc["properties"]["ucldc_schema:subjecttopic"]) > 0:
+        while topnumb < len(nxdoc["properties"]["ucldc_schema:subjecttopic"]):
             numb = topnumb + 1
             try:
                 name = "Subject (Topic) %d Heading" % numb
-                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "heading"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "heading"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
                                 "heading"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
-                        topnumb]["heading"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjecttopic"][topnumb]["heading"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Topic) %d Heading Type" % numb
-                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "headingtype"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "headingtype"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
                                 "headingtype"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
-                        topnumb]["headingtype"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjecttopic"][topnumb]["headingtype"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Topic) %d Source" % numb
-                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "source"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
                                 "source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
-                        topnumb]["source"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjecttopic"][topnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Subject (Topic) %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:subjecttopic"][topnumb][
-                        "authorityid"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:subjecttopic"][topnumb][
+                        "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:subjecttopic"][topnumb][
                                 "authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:subjecttopic"][
-                        topnumb]["authorityid"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:subjecttopic"][topnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
@@ -881,43 +933,44 @@ def get_subject_topic(data2, x, all_headers):
         data2["Subject (Topic) 1 Authority ID"] = ""
 
 
-def get_form_genre(data2, x, all_headers):
+def get_form_genre(data2, nxdoc, all_headers):
     formnumb = 0
-    if isinstance(x["properties"]["ucldc_schema:formgenre"],
-                  list) and len(x["properties"]["ucldc_schema:formgenre"]) > 0:
-        while formnumb < len(x["properties"]["ucldc_schema:formgenre"]):
+    if isinstance(
+            nxdoc["properties"]["ucldc_schema:formgenre"],
+            list) and len(nxdoc["properties"]["ucldc_schema:formgenre"]) > 0:
+        while formnumb < len(nxdoc["properties"]["ucldc_schema:formgenre"]):
             numb = formnumb + 1
             try:
                 name = "Form/Genre %d Heading" % numb
-                if x["properties"]["ucldc_schema:formgenre"][formnumb][
-                        "heading"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
+                        "heading"] is not None and nxdoc["properties"][
                             "ucldc_schema:formgenre"][formnumb][
                                 "heading"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:formgenre"][
-                        formnumb]["heading"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:formgenre"][formnumb]["heading"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Form/Genre %d Source" % numb
-                if x["properties"]["ucldc_schema:formgenre"][formnumb][
-                        "source"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
+                        "source"] is not None and nxdoc["properties"][
                             "ucldc_schema:formgenre"][formnumb]["source"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:formgenre"][
-                        formnumb]["source"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:formgenre"][formnumb]["source"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
                 pass
             try:
                 name = "Form/Genre %d Authority ID" % numb
-                if x["properties"]["ucldc_schema:formgenre"][formnumb][
-                        "authorityid"] is not None and x["properties"][
+                if nxdoc["properties"]["ucldc_schema:formgenre"][formnumb][
+                        "authorityid"] is not None and nxdoc["properties"][
                             "ucldc_schema:formgenre"][formnumb][
                                 "authorityid"] != "":
-                    data2[name] = x["properties"]["ucldc_schema:formgenre"][
-                        formnumb]["authorityid"]
+                    data2[name] = nxdoc["properties"][
+                        "ucldc_schema:formgenre"][formnumb]["authorityid"]
                 elif all_headers == "y":
                     data2[name] = ""
             except:
@@ -929,156 +982,56 @@ def get_form_genre(data2, x, all_headers):
         data2["Form/Genre 1 Authority ID"] = ""
 
 
-def get_provenance(data2, x, all_headers):
+def get_provenance(data2, nxdoc, all_headers):
     provnumb = 0
     if isinstance(
-            x["properties"]["ucldc_schema:provenance"],
-            list) and len(x["properties"]["ucldc_schema:provenance"]) > 0:
-        while provnumb < len(x["properties"]["ucldc_schema:provenance"]):
+            nxdoc["properties"]["ucldc_schema:provenance"],
+            list) and len(nxdoc["properties"]["ucldc_schema:provenance"]) > 0:
+        while provnumb < len(nxdoc["properties"]["ucldc_schema:provenance"]):
             numb = provnumb + 1
             name = "Provenance %d" % numb
-            data2[name] = x["properties"]["ucldc_schema:provenance"][provnumb]
+            data2[name] = nxdoc["properties"]["ucldc_schema:provenance"][
+                provnumb]
             provnumb += 1
     elif all_headers == "y":
         data2["Provenance 1"] = ""
 
 
-def get_physical_location(data2, x, all_headers):
-    if x["properties"]["ucldc_schema:physlocation"] is not None and x[
+def get_physical_location(data2, nxdoc, all_headers):
+    if nxdoc["properties"]["ucldc_schema:physlocation"] is not None and nxdoc[
             "properties"]["ucldc_schema:physlocation"] != "":
-        data2["Physical Location"] = x["properties"][
+        data2["Physical Location"] = nxdoc["properties"][
             "ucldc_schema:physlocation"]
     elif all_headers == "y":
         data2["Physical Location"] = ""
 
 
-def get_data_object_level(filepath, all_headers):
-    nx = utils.Nuxeo()
-    data = []
-    for n in nx.children(filepath):
-        data2 = {}
-
-        get_title(data2, n)
-        get_filepath(data2, n)
-        get_type(data2, n, all_headers)
-        get_alt_title(data2, n, all_headers)
-        get_identifier(data2, n, all_headers)
-        get_local_identifier(data2, n, all_headers)
-        get_campus_unit(data2, n, all_headers)
-        get_date(data2, n, all_headers)
-        get_publication(data2, n, all_headers)
-        get_creator(data2, n, all_headers)
-        get_contributor(data2, n, all_headers)
-        get_format(data2, n, all_headers)
-        get_description(data2, n, all_headers)
-        get_extent(data2, n, all_headers)
-        get_language(data2, n, all_headers)
-        get_temporal_coverage(data2, n, all_headers)
-        get_transcription(data2, n, all_headers)
-        get_access_restrictions(data2, n, all_headers)
-        get_rights_statement(data2, n, all_headers)
-        get_rights_status(data2, n, all_headers)
-        get_copyright_holder(data2, n, all_headers)
-        get_copyright_info(data2, n, all_headers)
-        get_collection(data2, n, all_headers)
-        get_related_resource(data2, n, all_headers)
-        get_source(data2, n, all_headers)
-        get_subject_name(data2, n, all_headers)
-        get_place(data2, n, all_headers)
-        get_subject_topic(data2, n, all_headers)
-        get_form_genre(data2, n, all_headers)
-        get_provenance(data2, n, all_headers)
-        get_physical_location(data2, n, all_headers)
-
-        data.append(data2)
-
-    fieldnames = [
-        "File path", "Title", "Type"
-    ]  #ensures that File path, Title and Type are the first three rows
+def sort_fieldnames(data):
+    """ ensures that File path, Title and Type are the first three rows
+    """
+    fieldnames = ["File path", "Title", "Type"]
     for data2 in data:
-        for key, value in data2.items():
+        for key in data2.keys():
             if key not in fieldnames:
                 fieldnames.append(key)
 
-    return {
-        "fieldnames":
-        fieldnames,
-        "data":
-        data,
-        "filename":
-        "nuxeo_object_%s.tsv" %
-        nx.get_metadata(path=filepath)["properties"]["dc:title"]
-    }
+    return fieldnames
 
 
-def get_data_item_level(filepath, all_headers):
-    nx = utils.Nuxeo()
-    data = []
-    for n in nx.children(filepath):
-        for x in nx.children(n["path"]):
-            data2 = {}
-            get_title(data2, x)
-            get_filepath(data2, x)
-            get_type(data2, x, all_headers)
-            get_alt_title(data2, x, all_headers)
-            get_identifier(data2, x, all_headers)
-            get_local_identifier(data2, x, all_headers)
-            get_campus_unit(data2, x, all_headers)
-            get_date(data2, x, all_headers)
-            get_publication(data2, x, all_headers)
-            get_creator(data2, x, all_headers)
-            get_contributor(data2, x, all_headers)
-            get_format(data2, x, all_headers)
-            get_description(data2, x, all_headers)
-            get_extent(data2, x, all_headers)
-            get_language(data2, x, all_headers)
-            get_temporal_coverage(data2, x, all_headers)
-            get_transcription(data2, x, all_headers)
-            get_access_restrictions(data2, x, all_headers)
-            get_rights_statement(data2, x, all_headers)
-            get_rights_status(data2, x, all_headers)
-            get_copyright_holder(data2, x, all_headers)
-            get_copyright_info(data2, x, all_headers)
-            get_collection(data2, x, all_headers)
-            get_related_resource(data2, x, all_headers)
-            get_source(data2, x, all_headers)
-            get_subject_name(data2, x, all_headers)
-            get_place(data2, x, all_headers)
-            get_subject_topic(data2, x, all_headers)
-            get_form_genre(data2, x, all_headers)
-            get_provenance(data2, x, all_headers)
-            get_physical_location(data2, x, all_headers)
-            data.append(data2)
-
-    fieldnames = [
-        "File path", "Title", "Type"
-    ]  #ensures that File path, Title and Type are the first three rows
-    for data2 in data:
-        for key, value in data2.items():
-            if key not in fieldnames:
-                fieldnames.append(key)
-
-    return {
-        "fieldnames":
-        fieldnames,
-        "data":
-        data,
-        "filename":
-        "nuxeo_item_%s.tsv" %
-        nx.get_metadata(path=filepath)["properties"]["dc:title"]
-    }
+def write_csv(data, filename, fieldnames, delimiter=","):
+    with open(filename, "wb") as outfile:
+        writer = csv.DictWriter(outfile,
+                                delimiter=delimiter,
+                                fieldnames=fieldnames)
+        writer.writeheader()
+        for row in data:
+            writer.writerow(row)
 
 
-# returns dictionary with fieldnames, data and filename;
-# This is used for google functions and writing to tsv
-# if google function not chosen
+def write_gsheet(data, sheet_name, fieldnames, gsheets_url):
 
-
-def google_object(filepath, all_headers, url):
-    import gspread
-    from oauth2client.service_account import ServiceAccountCredentials
-    obj = object_level(filepath, all_headers)
-    nx = utils.Nuxeo()
+    temp = "temp.csv"
+    write_csv(data, temp, fieldnames)
     scope = [
         "https://spreadsheets.google.com/feeds",
         "https://www.googleapis.com/auth/drive"
@@ -1086,47 +1039,12 @@ def google_object(filepath, all_headers, url):
     creds = ServiceAccountCredentials.from_json_keyfile_name(
         "client_secret.json", scope)
     client = gspread.authorize(creds)
-    with open("temp.csv", "wb") as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=obj["fieldnames"])
-        writer.writeheader()
-        for row in obj["data"]:
-            writer.writerow(row)
-    with open("temp.csv", encoding="utf8") as f:
+    with open(temp, encoding="utf8") as f:  #opens and reads temporary csv file
         s = f.read() + "\n"
-    sheet_id = client.open_by_url(url).id
-    client.import_csv(sheet_id, s)
-    client.open_by_key(sheet_id).sheet1.update_title(
-        "nuxeo_object_%s" %
-        nx.get_metadata(path=filepath)["properties"]["dc:title"])
-    os.remove("temp.csv")
-
-
-def google_item(filepath, all_headers, url):
-    import gspread
-    from oauth2client.service_account import ServiceAccountCredentials
-    item = item_level(filepath, all_headers)
-    nx = utils.Nuxeo()
-    scope = [
-        "https://spreadsheets.google.com/feeds",
-        "https://www.googleapis.com/auth/drive"
-    ]
-    creds = ServiceAccountCredentials.from_json_keyfile_name(
-        "client_secret.json", scope)
-    client = gspread.authorize(creds)
-    with open("temp.csv", "wb") as csvfile:  #creates temporary csv file
-        writer = csv.DictWriter(csvfile, fieldnames=item["fieldnames"])
-        writer.writeheader()
-        for row in item["data"]:
-            writer.writerow(row)
-    with open("temp.csv",
-              encoding="utf8") as f:  #opens and reads temporary csv file
-        s = f.read() + "\n"
-    sheet_id = client.open_by_url(url).id
+    sheet_id = client.open_by_url(gsheets_url).id
     client.import_csv(sheet_id, s)  #writes csv file to google sheet
-    client.open_by_key(sheet_id).sheet1.update_title(
-        "nuxeo_item_%s" %
-        nx.get_metadata(path=filepath)["properties"]["dc:title"])
-    os.remove("temp.csv")  #removes temporary csv
+    client.open_by_key(sheet_id).sheet1.update_title(sheet_name)
+    os.remove(temp)  #removes temporary csv
 
 
 if __name__ == "__main__":

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -74,7 +74,7 @@ def main():
             data.append(metadata_row)
 
     fieldnames = sort_fieldnames(data)
-    sheet_name = nuxeo_top_path.split("/")[-1]
+    sheet_name = nuxeo_top_path.split("/")[-1].lower()
 
     if gsheets_url:
         write_gsheet(data, sheet_name, fieldnames, gsheets_url)

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -146,7 +146,7 @@ def get_type(data2, nxdoc, all_headers):
     if nxdoc["properties"]["ucldc_schema:type"] is not None and nxdoc[
             "properties"]["ucldc_schema:type"] != "":
         data2["Type"] = nxdoc["properties"]["ucldc_schema:type"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Type"] = ""
 
 
@@ -163,7 +163,7 @@ def get_alt_title(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:alternativetitle"][
                 altnumb]
             altnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Alternative Title 1"] = ""
 
 
@@ -171,7 +171,7 @@ def get_identifier(data2, nxdoc, all_headers):
     if nxdoc["properties"]["ucldc_schema:identifier"] is not None and nxdoc[
             "properties"]["ucldc_schema:identifier"] != "":
         data2["Identifier"] = nxdoc["properties"]["ucldc_schema:identifier"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Identifier"] = ""
 
 
@@ -187,7 +187,7 @@ def get_local_identifier(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:localidentifier"][
                 locnumb]
             locnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Local Identifier 1"] = ""
 
 
@@ -202,7 +202,7 @@ def get_campus_unit(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:campusunit"][
                 campnumb]
             campnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Campus/Unit 1"] = ""
 
 
@@ -219,7 +219,7 @@ def get_date(data2, nxdoc, all_headers):
                             "ucldc_schema:date"][datenumb]["date"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["date"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -230,7 +230,7 @@ def get_date(data2, nxdoc, all_headers):
                             "ucldc_schema:date"][datenumb]["datetype"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["datetype"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -242,7 +242,7 @@ def get_date(data2, nxdoc, all_headers):
                                 "inclusivestart"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["inclusivestart"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -254,7 +254,7 @@ def get_date(data2, nxdoc, all_headers):
                                 "inclusiveend"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["inclusiveend"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -265,12 +265,12 @@ def get_date(data2, nxdoc, all_headers):
                             "ucldc_schema:date"][datenumb]["single"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:date"][
                         datenumb]["single"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             datenumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Date 1"] = ""
         data2["Date 1 Type"] = ""
         data2["Date 1 Inclusive Start"] = ""
@@ -289,7 +289,7 @@ def get_publication(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:publisher"][
                 pubnumb]
             pubnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Publication/Origination Info 1"] = ""
 
 
@@ -307,7 +307,7 @@ def get_creator(data2, nxdoc, all_headers):
                             "ucldc_schema:creator"][creatnumb]["name"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["name"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -319,7 +319,7 @@ def get_creator(data2, nxdoc, all_headers):
                                 "nametype"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["nametype"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -330,7 +330,7 @@ def get_creator(data2, nxdoc, all_headers):
                             "ucldc_schema:creator"][creatnumb]["role"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["role"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -341,7 +341,7 @@ def get_creator(data2, nxdoc, all_headers):
                             "ucldc_schema:creator"][creatnumb]["source"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -353,12 +353,12 @@ def get_creator(data2, nxdoc, all_headers):
                                 "authorityid"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:creator"][
                         creatnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             creatnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Creator 1 Name"] = ""
         data2["Creator 1 Name Type"] = ""
         data2["Creator 1 Role"] = ""
@@ -380,7 +380,7 @@ def get_contributor(data2, nxdoc, all_headers):
                             "ucldc_schema:contributor"][contnumb]["name"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:contributor"][contnumb]["name"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -392,7 +392,7 @@ def get_contributor(data2, nxdoc, all_headers):
                                 "nametype"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:contributor"][contnumb]["nametype"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -403,7 +403,7 @@ def get_contributor(data2, nxdoc, all_headers):
                             "ucldc_schema:contributor"][contnumb]["role"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:contributor"][contnumb]["role"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -415,7 +415,7 @@ def get_contributor(data2, nxdoc, all_headers):
                                 "source"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:contributor"][contnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -427,12 +427,12 @@ def get_contributor(data2, nxdoc, all_headers):
                                 "authorityid"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:contributor"][contnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             contnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Contributor 1 Name"] = ""
         data2["Contributor 1 Name Type"] = ""
         data2["Contributor 1 Role"] = ""
@@ -445,7 +445,7 @@ def get_format(data2, nxdoc, all_headers):
             "properties"]["ucldc_schema:physdesc"] != "":
         data2["Format/Physical Description"] = nxdoc["properties"][
             "ucldc_schema:physdesc"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Format/Physical Description"] = ""
 
 
@@ -463,7 +463,7 @@ def get_description(data2, nxdoc, all_headers):
                             "ucldc_schema:description"][descnumb]["item"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:description"][descnumb]["item"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -474,12 +474,12 @@ def get_description(data2, nxdoc, all_headers):
                             "ucldc_schema:description"][descnumb]["type"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:description"][descnumb]["type"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             descnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Description 1 Note"] = ""
         data2["Description 1 Type"] = ""
 
@@ -488,7 +488,7 @@ def get_extent(data2, nxdoc, all_headers):
     if nxdoc["properties"]["ucldc_schema:extent"] is not None and nxdoc[
             "properties"]["ucldc_schema:extent"] != "":
         data2["Extent"] = nxdoc["properties"]["ucldc_schema:extent"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Extent"] = ""
 
 
@@ -507,7 +507,7 @@ def get_language(data2, nxdoc, all_headers):
                                 "language"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:language"][
                         langnumb]["language"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -519,12 +519,12 @@ def get_language(data2, nxdoc, all_headers):
                                 "languagecode"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:language"][
                         langnumb]["languagecode"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             langnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Language 1"] = ""
         data2["Language 1 Code"] = ""
 
@@ -542,7 +542,7 @@ def get_temporal_coverage(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:temporalcoverage"][
                 tempnumb]
             tempnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Temporal Coverage 1"] = ""
 
 
@@ -551,7 +551,7 @@ def get_transcription(data2, nxdoc, all_headers):
             "properties"]["ucldc_schema:transcription"] != "":
         data2["Transcription"] = nxdoc["properties"][
             "ucldc_schema:transcription"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Transcription"] = ""
 
 
@@ -560,7 +560,7 @@ def get_access_restrictions(data2, nxdoc, all_headers):
             "properties"]["ucldc_schema:accessrestrict"] != "":
         data2["Access Restrictions"] = nxdoc["properties"][
             "ucldc_schema:accessrestrict"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Access Restrictions"] = ""
 
 
@@ -570,7 +570,7 @@ def get_rights_statement(data2, nxdoc, all_headers):
                 "properties"]["ucldc_schema:rightsstatement"] != "":
         data2["Copyright Statement"] = nxdoc["properties"][
             "ucldc_schema:rightsstatement"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Statement"] = ""
 
 
@@ -579,7 +579,7 @@ def get_rights_status(data2, nxdoc, all_headers):
             "properties"]["ucldc_schema:rightsstatus"] != "":
         data2["Copyright Status"] = nxdoc["properties"][
             "ucldc_schema:rightsstatus"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Status"] = ""
 
 
@@ -599,7 +599,7 @@ def get_copyright_holder(data2, nxdoc, all_headers):
                                 rightsnumb]["name"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:rightsholder"][rightsnumb]["name"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -611,7 +611,7 @@ def get_copyright_holder(data2, nxdoc, all_headers):
                                 rightsnumb]["nametype"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:rightsholder"][rightsnumb]["nametype"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -623,7 +623,7 @@ def get_copyright_holder(data2, nxdoc, all_headers):
                                 rightsnumb]["source"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:rightsholder"][rightsnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -635,12 +635,12 @@ def get_copyright_holder(data2, nxdoc, all_headers):
                                 rightsnumb]["authorityid"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:rightsholder"][rightsnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             rightsnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Holder 1 Name"] = ""
         data2["Copyright Holder 1 Name Type"] = ""
         data2["Copyright Holder 1 Source"] = ""
@@ -652,14 +652,14 @@ def get_copyright_info(data2, nxdoc, all_headers):
             "properties"]["ucldc_schema:rightscontact"] != "":
         data2["Copyright Contact"] = nxdoc["properties"][
             "ucldc_schema:rightscontact"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Contact"] = ""
 
     if nxdoc["properties"]["ucldc_schema:rightsnotice"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsnotice"] != "":
         data2["Copyright Notice"] = nxdoc["properties"][
             "ucldc_schema:rightsnotice"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Notice"] = ""
 
     if nxdoc["properties"][
@@ -667,7 +667,7 @@ def get_copyright_info(data2, nxdoc, all_headers):
                 "properties"]["ucldc_schema:rightsdeterminationdate"] != "":
         data2["Copyright Determination Date"] = nxdoc["properties"][
             "ucldc_schema:rightsdeterminationdate"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Determination Date"] = ""
 
     if nxdoc["properties"][
@@ -675,14 +675,14 @@ def get_copyright_info(data2, nxdoc, all_headers):
                 "properties"]["ucldc_schema:rightsstartdate"] != "":
         data2["Copyright Start Date"] = nxdoc["properties"][
             "ucldc_schema:rightsstartdate"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Start Date"] = ""
 
     if nxdoc["properties"]["ucldc_schema:rightsenddate"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsenddate"] != "":
         data2["Copyright End Date"] = nxdoc["properties"][
             "ucldc_schema:rightsenddate"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright End Date"] = ""
 
     if nxdoc["properties"][
@@ -690,14 +690,14 @@ def get_copyright_info(data2, nxdoc, all_headers):
                 "properties"]["ucldc_schema:rightsjurisdiction"] != "":
         data2["Copyright Jurisdiction"] = nxdoc["properties"][
             "ucldc_schema:rightsjurisdiction"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Jurisdiction"] = ""
 
     if nxdoc["properties"]["ucldc_schema:rightsnote"] is not None and nxdoc[
             "properties"]["ucldc_schema:rightsnote"] != "":
         data2["Copyright Note"] = nxdoc["properties"][
             "ucldc_schema:rightsnote"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Copyright Note"] = ""
 
 
@@ -712,7 +712,7 @@ def get_collection(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:collection"][
                 collnumb]
             collnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Collection 1"] = ""
 
 
@@ -728,7 +728,7 @@ def get_related_resource(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:relatedresource"][
                 relnumb]
             relnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Related Resource 1"] = ""
 
 
@@ -736,7 +736,7 @@ def get_source(data2, nxdoc, all_headers):
     if nxdoc["properties"]["ucldc_schema:source"] is not None and nxdoc[
             "properties"]["ucldc_schema:source"] != "":
         data2["Source"] = nxdoc["properties"]["ucldc_schema:source"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Source"] = ""
 
 
@@ -754,7 +754,7 @@ def get_subject_name(data2, nxdoc, all_headers):
                             "ucldc_schema:subjectname"][subnumb]["name"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjectname"][subnumb]["name"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -766,7 +766,7 @@ def get_subject_name(data2, nxdoc, all_headers):
                                 "name_type"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjectname"][subnumb]["name_type"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -777,7 +777,7 @@ def get_subject_name(data2, nxdoc, all_headers):
                             "ucldc_schema:subjectname"][subnumb]["role"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjectname"][subnumb]["role"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -789,7 +789,7 @@ def get_subject_name(data2, nxdoc, all_headers):
                                 "source"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjectname"][subnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -801,12 +801,12 @@ def get_subject_name(data2, nxdoc, all_headers):
                                 "authorityid"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjectname"][subnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             subnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Subject (Name) 1 Name"] = ""
         data2["Subject (Name) 1 Name Type"] = ""
         data2["Subject (Name) 1 Role"] = ""
@@ -827,7 +827,7 @@ def get_place(data2, nxdoc, all_headers):
                             "ucldc_schema:place"][plcnumb]["name"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["name"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -838,7 +838,7 @@ def get_place(data2, nxdoc, all_headers):
                             "ucldc_schema:place"][plcnumb]["coordinates"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["coordinates"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -849,7 +849,7 @@ def get_place(data2, nxdoc, all_headers):
                             "ucldc_schema:place"][plcnumb]["source"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -860,12 +860,12 @@ def get_place(data2, nxdoc, all_headers):
                             "ucldc_schema:place"][plcnumb]["authorityid"] != "":
                     data2[name] = nxdoc["properties"]["ucldc_schema:place"][
                         plcnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             plcnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Place 1 Name"] = ""
         data2["Place 1 Coordinates"] = ""
         data2["Place 1 Source"] = ""
@@ -887,7 +887,7 @@ def get_subject_topic(data2, nxdoc, all_headers):
                                 "heading"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjecttopic"][topnumb]["heading"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -899,7 +899,7 @@ def get_subject_topic(data2, nxdoc, all_headers):
                                 "headingtype"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjecttopic"][topnumb]["headingtype"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -911,7 +911,7 @@ def get_subject_topic(data2, nxdoc, all_headers):
                                 "source"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjecttopic"][topnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -923,12 +923,12 @@ def get_subject_topic(data2, nxdoc, all_headers):
                                 "authorityid"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:subjecttopic"][topnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             topnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Subject (Topic) 1 Heading"] = ""
         data2["Subject (Topic) 1 Heading Type"] = ""
         data2["Subject (Topic) 1 Source"] = ""
@@ -950,7 +950,7 @@ def get_form_genre(data2, nxdoc, all_headers):
                                 "heading"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:formgenre"][formnumb]["heading"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -961,7 +961,7 @@ def get_form_genre(data2, nxdoc, all_headers):
                             "ucldc_schema:formgenre"][formnumb]["source"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:formgenre"][formnumb]["source"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
@@ -973,12 +973,12 @@ def get_form_genre(data2, nxdoc, all_headers):
                                 "authorityid"] != "":
                     data2[name] = nxdoc["properties"][
                         "ucldc_schema:formgenre"][formnumb]["authorityid"]
-                elif all_headers == "y":
+                elif all_headers:
                     data2[name] = ""
             except:
                 pass
             formnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Form/Genre 1 Heading"] = ""
         data2["Form/Genre 1 Source"] = ""
         data2["Form/Genre 1 Authority ID"] = ""
@@ -995,7 +995,7 @@ def get_provenance(data2, nxdoc, all_headers):
             data2[name] = nxdoc["properties"]["ucldc_schema:provenance"][
                 provnumb]
             provnumb += 1
-    elif all_headers == "y":
+    elif all_headers:
         data2["Provenance 1"] = ""
 
 
@@ -1004,7 +1004,7 @@ def get_physical_location(data2, nxdoc, all_headers):
             "properties"]["ucldc_schema:physlocation"] != "":
         data2["Physical Location"] = nxdoc["properties"][
             "ucldc_schema:physlocation"]
-    elif all_headers == "y":
+    elif all_headers:
         data2["Physical Location"] = ""
 
 

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -53,14 +53,17 @@ def main():
     all_headers = args.all_headers
     gsheets_url = args.sheet.strip()
 
+    google_error_text = (
+        "\n*********\nWriting to Google document did not work."
+        "Make sure that Google document has been shared "
+        "with API key email address")
+
     if item_level:
         if gsheets_url:
             try:
                 google_item(nuxeo_top_path, all_headers, gsheets_url)
             except:
-                print("\n*********\nWriting to Google document did not work."
-                      "Make sure that Google document has been shared "
-                      "with API key email address")
+                print(google_error_text)
         else:
             item = item_level(nuxeo_top_path, all_headers)
             with open(item["filename"], "wb") as csvfile:
@@ -76,9 +79,7 @@ def main():
             try:
                 google_object(nuxeo_top_path, all_headers, gsheets_url)
             except:
-                print("\n*********\nWriting to Google document did not work."
-                      "Make sure that Google document has been shared "
-                      "with API key email address")
+                print(google_error_text)
         else:
             obj = object_level(nuxeo_top_path, all_headers)
             with open(obj["filename"], "wb") as csvfile:

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -46,7 +46,7 @@ def get_filepath(data2, x):
 
 
 def get_type(data2, x, all_headers):
-    """gets type, 
+    """gets type,
     inputs are dictionary (data2), nuxeo (x), all_headers input
     """
     if x['properties']['ucldc_schema:type'] != None and x['properties'][
@@ -998,7 +998,9 @@ def item_level(filepath):
     }
 
 
-#returns dictionary with fieldnames, data and filename; This is used for google functions and writing to tsv if google function not choosed
+# returns dictionary with fieldnames, data and filename;
+# This is used for google functions and writing to tsv
+# if google function not chosen
 
 
 def google_object(filepath, url):
@@ -1061,9 +1063,9 @@ if 'O' in choice or 'o' in choice:
         try:
             google_object(filepath, url)
         except:
-            print(
-                "\n*********\nWriting to Google document did not work. Make sure that Google document has been shared with API key email address"
-            )
+            print("\n*********\nWriting to Google document did not work."
+                  "Make sure that Google document has been shared "
+                  "with API key email address")
     else:
         obj = object_level(filepath)
         with open(obj['filename'], "wb") as csvfile:
@@ -1078,9 +1080,9 @@ if 'I' in choice or 'i' in choice:
         try:
             google_item(filepath, url)
         except:
-            print(
-                "\n*********\nWriting to Google document did not work. Make sure that Google document has been shared with API key email address"
-            )
+            print("\n*********\nWriting to Google document did not work."
+                  "Make sure that Google document has been shared "
+                  "with API key email address")
     else:
         item = item_level(filepath)
         with open(item['filename'], "wb") as csvfile:

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -65,7 +65,7 @@ def main():
             except:
                 print(google_error_text)
         else:
-            item = item_level(nuxeo_top_path, all_headers)
+            item = get_data_item_level(nuxeo_top_path, all_headers)
             with open(item["filename"], "wb") as csvfile:
                 writer = csv.DictWriter(csvfile,
                                         fieldnames=item["fieldnames"],
@@ -81,7 +81,7 @@ def main():
             except:
                 print(google_error_text)
         else:
-            obj = object_level(nuxeo_top_path, all_headers)
+            obj = get_data_object_level(nuxeo_top_path, all_headers)
             with open(obj["filename"], "wb") as csvfile:
                 writer = csv.DictWriter(csvfile,
                                         fieldnames=obj["fieldnames"],
@@ -952,7 +952,7 @@ def get_physical_location(data2, x, all_headers):
         data2["Physical Location"] = ""
 
 
-def object_level(filepath, all_headers):
+def get_data_object_level(filepath, all_headers):
     nx = utils.Nuxeo()
     data = []
     for n in nx.children(filepath):
@@ -1011,7 +1011,7 @@ def object_level(filepath, all_headers):
     }
 
 
-def item_level(filepath, all_headers):
+def get_data_item_level(filepath, all_headers):
     nx = utils.Nuxeo()
     data = []
     for n in nx.children(filepath):

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -90,20 +90,20 @@ def process_metadata(nxdoc):
     """ map Nuxeo JSON to flat data structure with human-readable labels
     """
 
-    data2 = {}
+    metadata_record = {}
 
-    get_single_string_fields(data2, nxdoc)
-    get_string_list_fields(data2, nxdoc)
-    get_dict_list_fields(data2, nxdoc)
+    get_single_string_fields(metadata_record, nxdoc)
+    get_string_list_fields(metadata_record, nxdoc)
+    get_dict_list_fields(metadata_record, nxdoc)
 
-    return data2
+    return metadata_record
 
 
-def get_single_string_fields(data2, nxdoc):
+def get_single_string_fields(metadata_record, nxdoc):
     """ map fields that are non-repeating string values
     """
 
-    data2["File path"] = nxdoc.get("path")
+    metadata_record["File path"] = nxdoc.get("path")
 
     property_map = {
         "Title": "dc:title",
@@ -126,10 +126,10 @@ def get_single_string_fields(data2, nxdoc):
     }
 
     for key, value in property_map.items():
-        data2[key] = nxdoc["properties"].get(value)
+        metadata_record[key] = nxdoc["properties"].get(value)
 
 
-def get_string_list_fields(data2, nxdoc):
+def get_string_list_fields(metadata_record, nxdoc):
     """ map fields that are flat lists of strings
     """
 
@@ -148,11 +148,11 @@ def get_string_list_fields(data2, nxdoc):
         num = 0
         while num < len(nxdoc["properties"].get(value)):
             field_label = key % (num + 1)
-            data2[field_label] = nxdoc["properties"].get(value)[num]
+            metadata_record[field_label] = nxdoc["properties"].get(value)[num]
             num += 1
 
 
-def get_dict_list_fields(data2, nxdoc):
+def get_dict_list_fields(metadata_record, nxdoc):
     """ map complex fields that are lists of dicts
     """
     complex_property_map = {
@@ -224,7 +224,7 @@ def get_dict_list_fields(data2, nxdoc):
         while num < len(field_data):
             for key, value in subfields.items():
                 field_label = key % (num + 1)
-                data2[field_label] = field_data[num].get(value)
+                metadata_record[field_label] = field_data[num].get(value)
             num += 1
 
 
@@ -258,8 +258,8 @@ def make_fieldnames(data, all_headers):
                 fieldnames.append(column)
     else:
         fieldnames = ["File path", "Title", "Type"]
-        for data2 in data:
-            for key in data2.keys():
+        for metadata_record in data:
+            for key in metadata_record.keys():
                 if key not in fieldnames:
                     fieldnames.append(key)
 

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -63,8 +63,9 @@ def get_type(data2, x, all_headers):
 
 def get_alt_title(data2, x, all_headers):
     altnumb = 0
-    if type(x['properties']['ucldc_schema:alternativetitle']) == list and len(
-            x['properties']['ucldc_schema:alternativetitle']) > 0:
+    if isinstance(x['properties']['ucldc_schema:alternativetitle'],
+                  list) and len(
+                      x['properties']['ucldc_schema:alternativetitle']) > 0:
         while altnumb < len(x['properties']['ucldc_schema:alternativetitle']):
             numb = altnumb + 1
             name = 'Alternative Title %d' % numb
@@ -85,8 +86,9 @@ def get_identifier(data2, x, all_headers):
 
 def get_local_identifier(data2, x, all_headers):
     locnumb = 0
-    if type(x['properties']['ucldc_schema:localidentifier']) == list and len(
-            x['properties']['ucldc_schema:localidentifier']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:localidentifier'],
+            list) and len(x['properties']['ucldc_schema:localidentifier']) > 0:
         while locnumb < len(x['properties']['ucldc_schema:localidentifier']):
             numb = locnumb + 1
             name = 'Local Identifier %d' % numb
@@ -99,8 +101,9 @@ def get_local_identifier(data2, x, all_headers):
 
 def get_campus_unit(data2, x, all_headers):
     campnumb = 0
-    if type(x['properties']['ucldc_schema:campusunit']) == list and len(
-            x['properties']['ucldc_schema:campusunit']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:campusunit'],
+            list) and len(x['properties']['ucldc_schema:campusunit']) > 0:
         while campnumb < len(x['properties']['ucldc_schema:campusunit']):
             numb = campnumb + 1
             name = 'Campus/Unit %d' % numb
@@ -112,8 +115,8 @@ def get_campus_unit(data2, x, all_headers):
 
 def get_date(data2, x, all_headers):
     datenumb = 0
-    if type(x['properties']['ucldc_schema:date']) == list and len(
-            x['properties']['ucldc_schema:date']) > 0:
+    if isinstance(x['properties']['ucldc_schema:date'],
+                  list) and len(x['properties']['ucldc_schema:date']) > 0:
         while datenumb < len(x['properties']['ucldc_schema:date']):
             numb = datenumb + 1
             try:
@@ -184,8 +187,8 @@ def get_date(data2, x, all_headers):
 
 def get_publication(data2, x, all_headers):
     pubnumb = 0
-    if type(x['properties']['ucldc_schema:publisher']) == list and len(
-            x['properties']['ucldc_schema:publisher']) > 0:
+    if isinstance(x['properties']['ucldc_schema:publisher'],
+                  list) and len(x['properties']['ucldc_schema:publisher']) > 0:
         while pubnumb < len(x['properties']['ucldc_schema:publisher']):
             numb = pubnumb + 1
             name = 'Publication/Origination Info %d' % numb
@@ -197,8 +200,8 @@ def get_publication(data2, x, all_headers):
 
 def get_creator(data2, x, all_headers):
     creatnumb = 0
-    if type(x['properties']['ucldc_schema:creator']) == list and len(
-            x['properties']['ucldc_schema:creator']) > 0:
+    if isinstance(x['properties']['ucldc_schema:creator'],
+                  list) and len(x['properties']['ucldc_schema:creator']) > 0:
         while creatnumb < len(x['properties']['ucldc_schema:creator']):
             numb = creatnumb + 1
             try:
@@ -269,8 +272,9 @@ def get_creator(data2, x, all_headers):
 
 def get_contributor(data2, x, all_headers):
     contnumb = 0
-    if type(x['properties']['ucldc_schema:contributor']) == list and len(
-            x['properties']['ucldc_schema:contributor']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:contributor'],
+            list) and len(x['properties']['ucldc_schema:contributor']) > 0:
         while contnumb < len(x['properties']['ucldc_schema:contributor']):
             numb = contnumb + 1
             try:
@@ -351,8 +355,9 @@ def get_format(data2, x, all_headers):
 
 def get_description(data2, x, all_headers):
     descnumb = 0
-    if type(x['properties']['ucldc_schema:description']) == list and len(
-            x['properties']['ucldc_schema:description']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:description'],
+            list) and len(x['properties']['ucldc_schema:description']) > 0:
         while descnumb < len(x['properties']['ucldc_schema:description']):
             numb = descnumb + 1
             try:
@@ -393,8 +398,8 @@ def get_extent(data2, x, all_headers):
 
 def get_language(data2, x, all_headers):
     langnumb = 0
-    if type(x['properties']['ucldc_schema:language']) == list and len(
-            x['properties']['ucldc_schema:language']) > 0:
+    if isinstance(x['properties']['ucldc_schema:language'],
+                  list) and len(x['properties']['ucldc_schema:language']) > 0:
         while langnumb < len(x['properties']['ucldc_schema:language']):
             numb = langnumb + 1
             try:
@@ -429,8 +434,9 @@ def get_language(data2, x, all_headers):
 
 def get_temporal_coverage(data2, x, all_headers):
     tempnumb = 0
-    if type(x['properties']['ucldc_schema:temporalcoverage']) == list and len(
-            x['properties']['ucldc_schema:temporalcoverage']) > 0:
+    if isinstance(x['properties']['ucldc_schema:temporalcoverage'],
+                  list) and len(
+                      x['properties']['ucldc_schema:temporalcoverage']) > 0:
         while tempnumb < len(x['properties']['ucldc_schema:temporalcoverage']):
             numb = tempnumb + 1
             name = 'Temporal Coverage %d' % numb
@@ -478,8 +484,9 @@ def get_rights_status(data2, x, all_headers):
 
 def get_copyright_holder(data2, x, all_headers):
     rightsnumb = 0
-    if type(x['properties']['ucldc_schema:rightsholder']) == list and len(
-            x['properties']['ucldc_schema:rightsholder']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:rightsholder'],
+            list) and len(x['properties']['ucldc_schema:rightsholder']) > 0:
         while rightsnumb < len(x['properties']['ucldc_schema:rightsholder']):
             numb = rightsnumb + 1
             try:
@@ -590,8 +597,9 @@ def get_copyright_info(data2, x, all_headers):
 
 def get_collection(data2, x, all_headers):
     collnumb = 0
-    if type(x['properties']['ucldc_schema:collection']) == list and len(
-            x['properties']['ucldc_schema:collection']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:collection'],
+            list) and len(x['properties']['ucldc_schema:collection']) > 0:
         while collnumb < len(x['properties']['ucldc_schema:collection']):
             numb = collnumb + 1
             name = 'Collection %d' % numb
@@ -603,8 +611,9 @@ def get_collection(data2, x, all_headers):
 
 def get_related_resource(data2, x, all_headers):
     relnumb = 0
-    if type(x['properties']['ucldc_schema:relatedresource']) == list and len(
-            x['properties']['ucldc_schema:relatedresource']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:relatedresource'],
+            list) and len(x['properties']['ucldc_schema:relatedresource']) > 0:
         while relnumb < len(x['properties']['ucldc_schema:relatedresource']):
             numb = relnumb + 1
             name = 'Related Resource %d' % numb
@@ -625,8 +634,9 @@ def get_source(data2, x, all_headers):
 
 def get_subject_name(data2, x, all_headers):
     subnumb = 0
-    if type(x['properties']['ucldc_schema:subjectname']) == list and len(
-            x['properties']['ucldc_schema:subjectname']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:subjectname'],
+            list) and len(x['properties']['ucldc_schema:subjectname']) > 0:
         while subnumb < len(x['properties']['ucldc_schema:subjectname']):
             numb = subnumb + 1
             try:
@@ -698,8 +708,8 @@ def get_subject_name(data2, x, all_headers):
 
 def get_place(data2, x, all_headers):
     plcnumb = 0
-    if type(x['properties']['ucldc_schema:place']) == list and len(
-            x['properties']['ucldc_schema:place']) > 0:
+    if isinstance(x['properties']['ucldc_schema:place'],
+                  list) and len(x['properties']['ucldc_schema:place']) > 0:
         while plcnumb < len(x['properties']['ucldc_schema:place']):
             numb = plcnumb + 1
             try:
@@ -756,8 +766,9 @@ def get_place(data2, x, all_headers):
 
 def get_subject_topic(data2, x, all_headers):
     topnumb = 0
-    if type(x['properties']['ucldc_schema:subjecttopic']) == list and len(
-            x['properties']['ucldc_schema:subjecttopic']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:subjecttopic'],
+            list) and len(x['properties']['ucldc_schema:subjecttopic']) > 0:
         while topnumb < len(x['properties']['ucldc_schema:subjecttopic']):
             numb = topnumb + 1
             try:
@@ -818,8 +829,8 @@ def get_subject_topic(data2, x, all_headers):
 
 def get_form_genre(data2, x, all_headers):
     formnumb = 0
-    if type(x['properties']['ucldc_schema:formgenre']) == list and len(
-            x['properties']['ucldc_schema:formgenre']) > 0:
+    if isinstance(x['properties']['ucldc_schema:formgenre'],
+                  list) and len(x['properties']['ucldc_schema:formgenre']) > 0:
         while formnumb < len(x['properties']['ucldc_schema:formgenre']):
             numb = formnumb + 1
             try:
@@ -866,8 +877,9 @@ def get_form_genre(data2, x, all_headers):
 
 def get_provenance(data2, x, all_headers):
     provnumb = 0
-    if type(x['properties']['ucldc_schema:provenance']) == list and len(
-            x['properties']['ucldc_schema:provenance']) > 0:
+    if isinstance(
+            x['properties']['ucldc_schema:provenance'],
+            list) and len(x['properties']['ucldc_schema:provenance']) > 0:
         while provnumb < len(x['properties']['ucldc_schema:provenance']):
             numb = provnumb + 1
             name = 'Provenance %d' % numb

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -1063,7 +1063,7 @@ def google_item(filepath, url):
     os.remove("temp.csv")  #removes temporary csv
 
 
-if 'O' in choice or 'o' in choice:
+if choice == "o":
     if 'http' in url:
         try:
             google_object(filepath, url)
@@ -1080,7 +1080,7 @@ if 'O' in choice or 'o' in choice:
             writer.writeheader()
             for row in obj['data']:
                 writer.writerow(row)
-if 'I' in choice or 'i' in choice:
+elif choice == "i":
     if 'http' in url:
         try:
             google_item(filepath, url)

--- a/export_nuxeo/export_nuxeo.py
+++ b/export_nuxeo/export_nuxeo.py
@@ -92,31 +92,25 @@ def process_metadata(nxdoc, all_headers):
 
     data2 = {}
 
-    get_simple_fields(data2, nxdoc)
+    get_single_string_fields(data2, nxdoc)
+    get_string_list_fields(data2, nxdoc)
 
-    get_alt_title(data2, nxdoc, all_headers)
-    get_local_identifier(data2, nxdoc, all_headers)
-    get_campus_unit(data2, nxdoc, all_headers)
     get_date(data2, nxdoc, all_headers)
-    get_publication(data2, nxdoc, all_headers)
+
     get_creator(data2, nxdoc, all_headers)
     get_contributor(data2, nxdoc, all_headers)
     get_description(data2, nxdoc, all_headers)
     get_language(data2, nxdoc, all_headers)
-    get_temporal_coverage(data2, nxdoc, all_headers)
     get_copyright_holder(data2, nxdoc, all_headers)
-    get_collection(data2, nxdoc, all_headers)
-    get_related_resource(data2, nxdoc, all_headers)
     get_subject_name(data2, nxdoc, all_headers)
     get_place(data2, nxdoc, all_headers)
     get_subject_topic(data2, nxdoc, all_headers)
     get_form_genre(data2, nxdoc, all_headers)
-    get_provenance(data2, nxdoc, all_headers)
 
     return data2
 
 
-def get_simple_fields(data2, nxdoc):
+def get_single_string_fields(data2, nxdoc):
     """ map fields that are non-repeating string values
     """
 
@@ -143,55 +137,30 @@ def get_simple_fields(data2, nxdoc):
     }
 
     for key, value in property_map.items():
-        data2[key] = nxdoc["properties"][value]
+        data2[key] = nxdoc["properties"].get(value)
 
 
-def get_alt_title(data2, nxdoc, all_headers):
-    altnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:alternativetitle"],
-            list) and len(
-                nxdoc["properties"]["ucldc_schema:alternativetitle"]) > 0:
-        while altnumb < len(
-                nxdoc["properties"]["ucldc_schema:alternativetitle"]):
-            num = altnumb + 1
-            name = "Alternative Title %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:alternativetitle"][
-                altnumb]
-            altnumb += 1
-    elif all_headers:
-        data2["Alternative Title 1"] = ""
+def get_string_list_fields(data2, nxdoc):
+    """ map fields that are flat lists of strings
+    """
 
+    property_map = {
+        "Alternative Title %d": "ucldc_schema:alternativetitle",
+        "Local Identifier %d": "ucldc_schema:localidentifier",
+        "Campus/Unit %d": "ucldc_schema:campusunit",
+        "Publication/Origination Info %d": "ucldc_schema:publisher",
+        "Temporal Coverage %d": "ucldc_schema:temporalcoverage",
+        "Collection %d": "ucldc_schema:collection",
+        "Related Resource %d": "ucldc_schema:relatedresource",
+        "Provenance %d": "ucldc_schema:provenance"
+    }
 
-def get_local_identifier(data2, nxdoc, all_headers):
-    locnumb = 0
-    if isinstance(nxdoc["properties"]["ucldc_schema:localidentifier"],
-                  list) and len(
-                      nxdoc["properties"]["ucldc_schema:localidentifier"]) > 0:
-        while locnumb < len(
-                nxdoc["properties"]["ucldc_schema:localidentifier"]):
-            num = locnumb + 1
-            name = "Local Identifier %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:localidentifier"][
-                locnumb]
-            locnumb += 1
-    elif all_headers:
-        data2["Local Identifier 1"] = ""
-
-
-def get_campus_unit(data2, nxdoc, all_headers):
-    campnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:campusunit"],
-            list) and len(nxdoc["properties"]["ucldc_schema:campusunit"]) > 0:
-        while campnumb < len(nxdoc["properties"]["ucldc_schema:campusunit"]):
-            num = campnumb + 1
-            name = "Campus/Unit %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:campusunit"][
-                campnumb]
-            campnumb += 1
-    elif all_headers:
-        data2["Campus/Unit 1"] = ""
+    for key, value in property_map.items():
+        num = 0
+        while num < len(nxdoc["properties"].get(value)):
+            field_label = key % (num + 1)
+            data2[field_label] = nxdoc["properties"].get(value)[num]
+            num += 1
 
 
 def get_date(data2, nxdoc, all_headers):
@@ -264,21 +233,6 @@ def get_date(data2, nxdoc, all_headers):
         data2["Date 1 Inclusive Start"] = ""
         data2["Date 1 Inclusive End"] = ""
         data2["Date 1 Single"] = ""
-
-
-def get_publication(data2, nxdoc, all_headers):
-    pubnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:publisher"],
-            list) and len(nxdoc["properties"]["ucldc_schema:publisher"]) > 0:
-        while pubnumb < len(nxdoc["properties"]["ucldc_schema:publisher"]):
-            num = pubnumb + 1
-            name = "Publication/Origination Info %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:publisher"][
-                pubnumb]
-            pubnumb += 1
-    elif all_headers:
-        data2["Publication/Origination Info 1"] = ""
 
 
 def get_creator(data2, nxdoc, all_headers):
@@ -500,23 +454,6 @@ def get_language(data2, nxdoc, all_headers):
         data2["Language 1 Code"] = ""
 
 
-def get_temporal_coverage(data2, nxdoc, all_headers):
-    tempnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:temporalcoverage"],
-            list) and len(
-                nxdoc["properties"]["ucldc_schema:temporalcoverage"]) > 0:
-        while tempnumb < len(
-                nxdoc["properties"]["ucldc_schema:temporalcoverage"]):
-            num = tempnumb + 1
-            name = "Temporal Coverage %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:temporalcoverage"][
-                tempnumb]
-            tempnumb += 1
-    elif all_headers:
-        data2["Temporal Coverage 1"] = ""
-
-
 def get_copyright_holder(data2, nxdoc, all_headers):
     rightsnumb = 0
     if isinstance(nxdoc["properties"]["ucldc_schema:rightsholder"],
@@ -579,37 +516,6 @@ def get_copyright_holder(data2, nxdoc, all_headers):
         data2["Copyright Holder 1 Name Type"] = ""
         data2["Copyright Holder 1 Source"] = ""
         data2["Copyright Holder 1 Authority ID"] = ""
-
-
-def get_collection(data2, nxdoc, all_headers):
-    collnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:collection"],
-            list) and len(nxdoc["properties"]["ucldc_schema:collection"]) > 0:
-        while collnumb < len(nxdoc["properties"]["ucldc_schema:collection"]):
-            num = collnumb + 1
-            name = "Collection %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:collection"][
-                collnumb]
-            collnumb += 1
-    elif all_headers:
-        data2["Collection 1"] = ""
-
-
-def get_related_resource(data2, nxdoc, all_headers):
-    relnumb = 0
-    if isinstance(nxdoc["properties"]["ucldc_schema:relatedresource"],
-                  list) and len(
-                      nxdoc["properties"]["ucldc_schema:relatedresource"]) > 0:
-        while relnumb < len(
-                nxdoc["properties"]["ucldc_schema:relatedresource"]):
-            num = relnumb + 1
-            name = "Related Resource %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:relatedresource"][
-                relnumb]
-            relnumb += 1
-    elif all_headers:
-        data2["Related Resource 1"] = ""
 
 
 def get_subject_name(data2, nxdoc, all_headers):
@@ -854,21 +760,6 @@ def get_form_genre(data2, nxdoc, all_headers):
         data2["Form/Genre 1 Heading"] = ""
         data2["Form/Genre 1 Source"] = ""
         data2["Form/Genre 1 Authority ID"] = ""
-
-
-def get_provenance(data2, nxdoc, all_headers):
-    provnumb = 0
-    if isinstance(
-            nxdoc["properties"]["ucldc_schema:provenance"],
-            list) and len(nxdoc["properties"]["ucldc_schema:provenance"]) > 0:
-        while provnumb < len(nxdoc["properties"]["ucldc_schema:provenance"]):
-            num = provnumb + 1
-            name = "Provenance %d" % num
-            data2[name] = nxdoc["properties"]["ucldc_schema:provenance"][
-                provnumb]
-            provnumb += 1
-    elif all_headers:
-        data2["Provenance 1"] = ""
 
 
 def make_fieldnames(data, all_headers):

--- a/export_nuxeo/simple_ucldc.json
+++ b/export_nuxeo/simple_ucldc.json
@@ -1,0 +1,106 @@
+{
+    "string":
+    {
+        "Title": "dc:title",
+        "Identifier": "ucldc_schema:identifier",
+        "Type": "ucldc_schema:type",
+        "Format/Physical Description": "ucldc_schema:physdesc",
+        "Extent": "ucldc_schema:extent",
+        "Transcription": "ucldc_schema:transcription",
+        "Access Restrictions": "ucldc_schema:accessrestrict",
+        "Copyright Statement": "ucldc_schema:rightsstatement",
+        "Copyright Status": "ucldc_schema:rightsstatus",
+        "Copyright Contact": "ucldc_schema:rightscontact",
+        "Copyright Notice": "ucldc_schema:rightsnotice",
+        "Copyright Determination Date": "ucldc_schema:rightsdeterminationdate",
+        "Copyright End Date": "ucldc_schema:rightsstartdate",
+        "Copyright Jurisdiction": "ucldc_schema:rightsjurisdiction",
+        "Copyright Note": "ucldc_schema:rightsnote",
+        "Source": "ucldc_schema:source",
+        "Physical Location": "ucldc_schema:physlocation"
+    },
+    "string_list":
+    {
+        "Alternative Title %d": "ucldc_schema:alternativetitle",
+        "Local Identifier %d": "ucldc_schema:localidentifier",
+        "Campus/Unit %d": "ucldc_schema:campusunit",
+        "Publication/Origination Info %d": "ucldc_schema:publisher",
+        "Temporal Coverage %d": "ucldc_schema:temporalcoverage",
+        "Collection %d": "ucldc_schema:collection",
+        "Related Resource %d": "ucldc_schema:relatedresource",
+        "Provenance %d": "ucldc_schema:provenance"
+    },
+    "complex_list":
+    {
+        "ucldc_schema:date":
+        {
+            "Date %d": "date",
+            "Date %d Type": "datetype",
+            "Date %d Inclusive Start": "inclusivestart",
+            "Date %d Inclusive End": "inclusiveend",
+            "Date %d Single": "single"
+        },
+        "ucldc_schema:creator":
+        {
+            "Creator %d Name": "name",
+            "Creator %d Name Type": "nametype",
+            "Creator %d Role": "role",
+            "Creator %d Source": "source",
+            "Creator %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:contributor":
+        {
+            "Contributor %d Name": "name",
+            "Contributor %d Name Type": "nametype",
+            "Contributor %d Role": "role",
+            "Contributor %d Source": "source",
+            "Contributor %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:description":
+        {
+            "Description %d Note": "item",
+            "Description %d Type": "type"
+        },
+        "ucldc_schema:language":
+        {
+            "Language %d": "language",
+            "Language %d Code": "languagecode"
+        },
+        "ucldc_schema:rightsholder":
+        {
+            "Copyright Holder %d Name": "name",
+            "Copyright Holder %d Name Type": "nametype",
+            "Copyright Holder %d Role": "role",
+            "Copyright Holder %d Source": "source",
+            "Copyright Holder %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:subjectname":
+        {
+            "Contributor %d Name": "name",
+            "Contributor %d Name Type": "nametype",
+            "Contributor %d Role": "role",
+            "Contributor %d Source": "source",
+            "Contributor %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:place":
+        {
+            "Place %d Name": "name",
+            "Place %d Source": "source",
+            "Place %d Coordinates": "coordinates",
+            "Place %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:subjecttopic":
+        {
+            "Subject (Topic) %d Heading": "heading",
+            "Subject (Topic) %d Heading Type": "headingtype",
+            "Subject (Topic) %d Source": "source",
+            "Subject (Topic) %d Authority ID": "authorityid"
+        },
+        "ucldc_schema:formgenre":
+        {
+            "Form/Genre %d Heading": "heading",
+            "Form/Genre %d Source": "source",
+            "Form/Genre %d Authority ID": "authorityid"
+        }
+    }
+}


### PR DESCRIPTION
This fixes a minor but longstanding issue where the export script doesn't export the "Language Code" field. This is because the code that attempted to access that field used the wrong key ("code" instead of "languagecode").